### PR TITLE
Add cleanup metrics and connection pooling

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,17 @@
+name: Format
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@v1
+        with:
+          args: --format github
+      - uses: psf/black@stable
+        with:
+          options: "--check"
+      - uses: jitsucom/sqlfluff-action@v1
+        with:
+          dialect: postgres
+          paths: "metrics/**/*.sql"

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+history/
+output/
+

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,3 @@
+[sqlfluff]
+dialect = postgres
+exclude_rules = L003

--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
 # OSM-CACLR-address-dashboard
-Dashboard to help conflate OSM with CACLR
+
+This repository contains scripts to generate a static HTML dashboard for the Luxembourg address import. The dashboard is intended to be run via `cron` and does not require any CGI components.
+The code targets **Python 3.12** and uses the [uv](https://github.com/astral-sh/uv) package manager which will be installed automatically when running the scripts.
+
+## Configuration
+
+Copy `config.ini` and adapt the database connection settings and output paths.
+The configuration file is read automatically when running the scripts. It also
+contains paths for the output directory, history data and the locations of the
+metric SQL files and includes. Connection parameters like `host` and `password`
+may be left blank when using socket based authentication.
+Queries used for the metrics live in the directory configured with
+`metrics_dir` (default `metrics`) as individual SQL files. Metrics can be
+organised in sub-directories such as `cleanup/` and `context/`. Optional
+snippets can be placed in the directory configured by `includes_dir` (default
+`includes`) and referenced from the metrics using a comment of the form
+`-- include FILE.sql`. Each SQL file should start with two comment lines: one for
+the title and one for the description. These are shown on the dashboard.
+
+## Generating the dashboard
+
+```
+./scripts/generate_dashboard.py
+```
+
+This will create `index.html` and small trend graphs inside the directory
+specified by `output_dir` in the configuration file. Each metric row can be
+expanded to show the underlying rows, and if the query returns OSM IDs a "Load
+in JOSM" link is offered. The script uses an
+[uv](https://github.com/astral-sh/uv) shebang to automatically install its Python dependencies.
+Queries run concurrently so the dashboard builds quickly.
+
+### Running the tests
+
+```
+pytest
+```
+
+### Code style
+
+Python code is formatted with `black` and linted with `ruff`. SQL files are
+checked with `sqlfluff`. These run automatically via GitHub Actions.
+
+## Programmatic checks
+
+Run the following command before committing changes:
+
+```
+python -m py_compile $(git ls-files '*.py')
+```
+
+## Database schema
+
+The scripts expect two tables to be available:
+
+`addresses` with at least the columns
+`id_caclr_bat`, `id_caclr_rue`, `numero`, `rue`, `localite`, `code_postal`,
+`geom` (geometry in EPSG:4326) and optional `lat_wgs84`/`lon_wgs84` numeric
+columns.
+
+`parcelles` with a primary key `id_parcell` and a polygon column
+`wkb_geometry` in EPSG:4326 used when checking wrong parcel matches.

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,17 @@
+[database]
+# leave host empty to use the local socket
+host=
+port=5432
+dbname=caclr
+user=osm
+# empty password means libpq will rely on your pg_hba.conf
+password=
+
+[paths]
+output_dir=output
+history_dir=history
+metrics_dir=metrics
+includes_dir=includes
+
+[general]
+josm_remote_url=http://localhost:8111/load_object?objects={object_ids}

--- a/includes/osm_potential_addresses.sql
+++ b/includes/osm_potential_addresses.sql
@@ -1,0 +1,19 @@
+WITH osm_potential_addresses AS (
+    SELECT osm_id, 'node' AS osm_type,
+           "addr:housenumber", "addr:street", "addr:postcode",
+           "addr:city", "ref:caclr"
+    FROM planet_osm_point
+    WHERE "addr:housenumber" IS NOT NULL
+      AND "addr:street" IS NOT NULL
+      AND "addr:postcode" IS NOT NULL
+      AND "addr:city" IS NOT NULL
+    UNION
+    SELECT osm_id, 'way' AS osm_type,
+           "addr:housenumber", "addr:street", "addr:postcode",
+           "addr:city", "ref:caclr"
+    FROM planet_osm_polygon
+    WHERE "addr:housenumber" IS NOT NULL
+      AND "addr:street" IS NOT NULL
+      AND "addr:postcode" IS NOT NULL
+      AND "addr:city" IS NOT NULL
+)

--- a/metrics/cleanup/addr_interpolation.sql
+++ b/metrics/cleanup/addr_interpolation.sql
@@ -1,0 +1,5 @@
+-- Title: addr:interpolation ways
+-- Description: Ways tagged with addr:interpolation
+SELECT osm_id, 'way' AS osm_type, "addr:interpolation"
+FROM planet_osm_line
+WHERE "addr:interpolation" IS NOT NULL;

--- a/metrics/cleanup/addresses_without_housenumber.sql
+++ b/metrics/cleanup/addresses_without_housenumber.sql
@@ -1,0 +1,3 @@
+-- Title: Addresses without housenumber
+-- Description: Entries in the dataset that have no house number
+select * from addresses where numero is null;

--- a/metrics/cleanup/addresses_without_housenumber_not_in_osm.sql
+++ b/metrics/cleanup/addresses_without_housenumber_not_in_osm.sql
@@ -1,0 +1,10 @@
+-- Title: Missing number not in OSM
+-- Description: Addresses without a housenumber that also do not exist in OSM
+-- include osm_potential_addresses.sql
+SELECT addresses.*
+FROM addresses
+LEFT JOIN osm_potential_addresses ON addresses.id_caclr_bat = osm_potential_addresses."ref:caclr"
+WHERE addresses.numero IS NULL
+  AND osm_potential_addresses.osm_id IS NULL
+  AND addresses.localite NOT IN ('Luxembourg')
+ORDER BY addresses.localite, addresses.rue;

--- a/metrics/cleanup/associatedstreet_relations.sql
+++ b/metrics/cleanup/associatedstreet_relations.sql
@@ -1,0 +1,5 @@
+-- Title: associatedStreet relations
+-- Description: Relations of type associatedStreet
+SELECT id AS osm_id, 'relation' AS osm_type
+FROM planet_osm_rels
+WHERE tags->'type' = 'associatedStreet';

--- a/metrics/cleanup/caclr_mismatch.sql
+++ b/metrics/cleanup/caclr_mismatch.sql
@@ -1,0 +1,7 @@
+-- Title: CACLR mismatch
+-- Description: Addresses tagged with ref:caclr where the street or city differs from the official record
+-- include osm_potential_addresses.sql
+SELECT count(*) FROM osm_potential_addresses, addresses
+WHERE osm_potential_addresses."ref:caclr" = addresses.id_caclr_bat
+  AND (osm_potential_addresses."addr:street" != addresses.rue
+    OR osm_potential_addresses."addr:city" != addresses.localite);

--- a/metrics/cleanup/duplicate_osm_addresses.sql
+++ b/metrics/cleanup/duplicate_osm_addresses.sql
@@ -1,0 +1,9 @@
+-- Title: Duplicate OSM addresses
+-- Description: Multiple OSM objects share the same housenumber, street and city
+-- include osm_potential_addresses.sql
+select "addr:housenumber", "addr:street", "addr:city", count(*)
+from osm_potential_addresses
+where "addr:housenumber" is not null
+group by "addr:housenumber", "addr:street", "addr:city"
+having count(*) > 1
+order by count desc, "addr:city", "addr:street", "addr:housenumber";

--- a/metrics/cleanup/far_match_addresses.sql
+++ b/metrics/cleanup/far_match_addresses.sql
@@ -1,0 +1,16 @@
+-- Title: Far matches
+-- Description: OSM addresses matching CACLR but located more than 30m away
+-- include osm_potential_addresses.sql
+select * from (SELECT   osm.*, 
+         caclr.id_caclr_bat, 
+         St_distance(St_centroid(osm.way), St_transform(caclr.geom, 3857)) AS dist,
+         St_transform(caclr.geom, 3857) AS caclr_geom,
+         St_astext(St_shortestline(St_centroid(osm.way), St_transform(caclr.geom, 3857))) as line
+FROM     osm_potential_addresses osm, 
+         addresses caclr 
+WHERE    osm."ref:caclr" IS NULL 
+AND      osm."addr:housenumber" = caclr.numero 
+AND      osm."addr:city" = caclr.localite 
+AND      osm."addr:postcode" = caclr.code_postal::text 
+AND      osm."addr:street" = caclr.rue 
+ORDER BY dist DESC) as foo where dist > 30;

--- a/metrics/cleanup/garbage_housenumbers.sql
+++ b/metrics/cleanup/garbage_housenumbers.sql
@@ -1,0 +1,3 @@
+-- Title: Garbage house numbers
+-- Description: Addresses with trailing punctuation in the house number
+select numero, rue, localite from addresses where numero ~ '\\.$';

--- a/metrics/cleanup/housenames_only.sql
+++ b/metrics/cleanup/housenames_only.sql
@@ -1,0 +1,3 @@
+-- Title: Housename only streets
+-- Description: Streets that only have addresses without numbers
+select * from addresses as ass where numero is null and not exists(select rue from addresses where numero is not null and id_caclr_rue = ass.id_caclr_rue);

--- a/metrics/cleanup/housenumber_comma.sql
+++ b/metrics/cleanup/housenumber_comma.sql
@@ -1,0 +1,6 @@
+-- Title: Comma in housenumbers
+-- Description: Housenumbers containing commas
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:housenumber" ~ ',';

--- a/metrics/cleanup/housenumber_invalid_format.sql
+++ b/metrics/cleanup/housenumber_invalid_format.sql
@@ -1,0 +1,18 @@
+-- Title: Invalid housenumber format
+-- Description: OSM housenumbers not matching the expected pattern
+WITH osm_potential_addresses AS (
+    SELECT osm_id, 'node' AS osm_type,
+           "addr:housenumber", "addr:street", "addr:postcode",
+           "addr:city"
+    FROM planet_osm_point
+    WHERE "addr:housenumber" IS NOT NULL
+    UNION
+    SELECT osm_id, 'way' AS osm_type,
+           "addr:housenumber", "addr:street", "addr:postcode",
+           "addr:city"
+    FROM planet_osm_polygon
+    WHERE "addr:housenumber" IS NOT NULL
+)
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:housenumber" !~ '^[1-9][0-9]{0,2}[A-Z]{0,3}(-*[1-9][0-9]{0,2}[A-Z]{0,3}){0,4}$';

--- a/metrics/cleanup/housenumber_leading_zero.sql
+++ b/metrics/cleanup/housenumber_leading_zero.sql
@@ -1,0 +1,6 @@
+-- Title: Leading zero housenumbers
+-- Description: Housenumbers starting with zero
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:housenumber" ~ '^0';

--- a/metrics/cleanup/housenumber_lowercase.sql
+++ b/metrics/cleanup/housenumber_lowercase.sql
@@ -1,0 +1,6 @@
+-- Title: Lowercase housenumbers
+-- Description: Housenumbers containing lowercase letters
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:housenumber" ~ '[a-z]';

--- a/metrics/cleanup/housenumber_not_numeric.sql
+++ b/metrics/cleanup/housenumber_not_numeric.sql
@@ -1,0 +1,6 @@
+-- Title: Non-numeric housenumbers
+-- Description: Housenumbers starting with letters
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:housenumber" ~ '^[A-Z]';

--- a/metrics/cleanup/housenumber_semicolon.sql
+++ b/metrics/cleanup/housenumber_semicolon.sql
@@ -1,0 +1,6 @@
+-- Title: Semicolon in housenumbers
+-- Description: Housenumbers containing semicolons
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:housenumber" ~ ';';

--- a/metrics/cleanup/housenumber_slash.sql
+++ b/metrics/cleanup/housenumber_slash.sql
@@ -1,0 +1,6 @@
+-- Title: Slash in housenumbers
+-- Description: Housenumbers containing slashes
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:housenumber" ~ '/';

--- a/metrics/cleanup/housenumber_whitespace.sql
+++ b/metrics/cleanup/housenumber_whitespace.sql
@@ -1,0 +1,6 @@
+-- Title: Whitespace in housenumbers
+-- Description: Housenumbers containing spaces
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:housenumber" ~ ' ';

--- a/metrics/cleanup/invalid_street_postcode.sql
+++ b/metrics/cleanup/invalid_street_postcode.sql
@@ -1,0 +1,8 @@
+-- Title: Invalid street/postcode
+-- Description: Street and postcode pairs that do not exist in CACLR
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:postcode", "addr:city"
+FROM osm_potential_addresses
+WHERE ("addr:street", "addr:postcode") NOT IN (
+    SELECT rue, code_postal::text FROM addresses
+);

--- a/metrics/cleanup/missing_caclr_reference.sql
+++ b/metrics/cleanup/missing_caclr_reference.sql
@@ -1,0 +1,9 @@
+-- Title: Missing CACLR reference
+-- Description: ref:caclr values present in OSM but not in the official dataset
+-- include osm_potential_addresses.sql
+SELECT count(*) FROM (
+    SELECT DISTINCT "ref:caclr" FROM osm_potential_addresses
+    WHERE "ref:caclr" NOT IN ('missing', 'wrong')
+    EXCEPT
+    SELECT id_caclr_bat FROM addresses
+) AS foo;

--- a/metrics/cleanup/missing_city.sql
+++ b/metrics/cleanup/missing_city.sql
@@ -1,0 +1,9 @@
+-- Title: Missing city
+-- Description: OSM addresses lacking a city tag
+SELECT osm_id, 'node' AS osm_type, "addr:housenumber", "addr:street"
+FROM planet_osm_point
+WHERE "addr:housenumber" IS NOT NULL AND "addr:city" IS NULL
+UNION
+SELECT osm_id, 'way' AS osm_type, "addr:housenumber", "addr:street"
+FROM planet_osm_polygon
+WHERE "addr:housenumber" IS NOT NULL AND "addr:city" IS NULL;

--- a/metrics/cleanup/missing_housenumber_existing_street.sql
+++ b/metrics/cleanup/missing_housenumber_existing_street.sql
@@ -1,0 +1,5 @@
+-- Title: Missing number on existing street
+-- Description: Addresses without number where the street also has numbered entries
+select * from addresses as ass
+where numero is null
+and exists(select rue from addresses where numero is not null and id_caclr_rue = ass.id_caclr_rue);

--- a/metrics/cleanup/missing_postcode.sql
+++ b/metrics/cleanup/missing_postcode.sql
@@ -1,0 +1,13 @@
+-- Title: Missing postcode
+-- Description: OSM addresses with housenumber and street but no postcode
+SELECT osm_id, 'node' AS osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM planet_osm_point
+WHERE "addr:housenumber" IS NOT NULL
+  AND "addr:street" IS NOT NULL
+  AND "addr:postcode" IS NULL
+UNION
+SELECT osm_id, 'way' AS osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM planet_osm_polygon
+WHERE "addr:housenumber" IS NOT NULL
+  AND "addr:street" IS NOT NULL
+  AND "addr:postcode" IS NULL;

--- a/metrics/cleanup/no_match_in_caclr.sql
+++ b/metrics/cleanup/no_match_in_caclr.sql
@@ -1,0 +1,29 @@
+-- Title: No match in CACLR
+-- Description: OSM addresses that cannot be matched to CACLR
+WITH osm_potential_addresses AS (
+    SELECT osm_id, 'node' AS osm_type, osm_user, name,
+           "addr:housenumber", "addr:street", "addr:postcode",
+           "addr:city", "ref:caclr", way
+    FROM planet_osm_point
+    WHERE "addr:street" IS NOT NULL
+    UNION
+    SELECT osm_id, 'way' AS osm_type, osm_user, name,
+           "addr:housenumber", "addr:street", "addr:postcode",
+           "addr:city", "ref:caclr", way
+    FROM planet_osm_polygon
+    WHERE "addr:street" IS NOT NULL
+)
+SELECT osm_id, osm_type, url, osm_user,
+       "addr:housenumber" AS numero,
+       "addr:street" AS rue,
+       "addr:postcode" AS codepostal,
+       "addr:city" AS localite
+FROM (
+    SELECT osm_id, osm_type, osm_user, name, "addr:housenumber",
+           "addr:street", "addr:postcode", "addr:city", "ref:caclr",
+           concat('https://osm.org/', CASE WHEN osm_type='node' THEN 'node/' ELSE 'way/' END, osm_id) AS url
+    FROM osm_potential_addresses
+) AS osm
+LEFT JOIN addresses ON addresses.numero = osm."addr:housenumber" AND addresses.localite = osm."addr:city" AND addresses.rue = osm."addr:street"
+WHERE addresses.localite IS NULL AND osm."ref:caclr" IS NULL AND osm."addr:housenumber" NOT LIKE '%-%'
+ORDER BY localite, rue, numero;

--- a/metrics/cleanup/osm_no_number_or_name.sql
+++ b/metrics/cleanup/osm_no_number_or_name.sql
@@ -1,0 +1,16 @@
+-- Title: OSM objects without number or name
+-- Description: Objects with addr:street but neither housenumber nor housename
+WITH osm_potential_addresses AS (
+    SELECT osm_id, 'node' AS osm_type,
+           "addr:housenumber", "addr:housename", "addr:street"
+    FROM planet_osm_point
+    WHERE "addr:street" IS NOT NULL
+    UNION
+    SELECT osm_id, 'way' AS osm_type,
+           "addr:housenumber", "addr:housename", "addr:street"
+    FROM planet_osm_polygon
+    WHERE "addr:street" IS NOT NULL
+)
+SELECT osm_id, osm_type, "addr:street"
+FROM osm_potential_addresses
+WHERE "addr:housenumber" IS NULL AND "addr:housename" IS NULL;

--- a/metrics/cleanup/postcode_prefix_l.sql
+++ b/metrics/cleanup/postcode_prefix_l.sql
@@ -1,0 +1,5 @@
+-- Title: Postcodes with L prefix
+-- Description: Addresses with postcode starting with L or L-
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:postcode" FROM osm_potential_addresses
+WHERE "addr:postcode" ILIKE 'L%' OR "addr:postcode" ILIKE 'L-%';

--- a/metrics/cleanup/ref_missing_wrong.sql
+++ b/metrics/cleanup/ref_missing_wrong.sql
@@ -1,0 +1,24 @@
+-- Title: Possibly incorrect missing ref
+-- Description: Objects tagged ref:caclr=missing but overlapping a CACLR address
+-- include osm_potential_addresses.sql
+SELECT
+         osm.osm_id,
+         osm.osm_type,
+         concat('https://osm.org/',
+                CASE WHEN osm.osm_type='node' THEN 'node/' ELSE 'way/' END,
+                osm.osm_id) AS url,
+         osm_user,
+         osm."addr:housenumber",
+         caclr.numero,
+         osm."addr:street",
+         caclr.rue,
+         osm."addr:city",
+         caclr.localite,
+         osm."note:caclr",
+         osm."note", 
+         caclr.id_caclr_bat
+FROM     osm_potential_addresses osm, 
+         addresses caclr
+WHERE    osm."ref:caclr" like 'missing' 
+AND      st_intersects(osm.way, St_transform(caclr.geom, 3857))
+order by localite, rue, numero;

--- a/metrics/cleanup/same_position_addresses.sql
+++ b/metrics/cleanup/same_position_addresses.sql
@@ -1,0 +1,8 @@
+-- Title: Same position addresses
+-- Description: Multiple addresses sharing identical coordinates
+SELECT count(*) FROM (
+    SELECT lat_wgs84, lon_wgs84
+    FROM addresses
+    GROUP BY lat_wgs84, lon_wgs84
+    HAVING count(*) > 1
+) AS foo;

--- a/metrics/cleanup/unclosed_address_ways.sql
+++ b/metrics/cleanup/unclosed_address_ways.sql
@@ -1,0 +1,7 @@
+-- Title: Addressed open ways
+-- Description: Ways with address tags that are not closed
+SELECT osm_id, 'way' AS osm_type, "addr:housenumber", "addr:street"
+FROM planet_osm_line
+WHERE ("addr:housenumber" IS NOT NULL OR "addr:street" IS NOT NULL OR
+       "addr:city" IS NOT NULL OR "addr:postcode" IS NOT NULL)
+  AND NOT ST_IsClosed(way);

--- a/metrics/cleanup/unknown_cities.sql
+++ b/metrics/cleanup/unknown_cities.sql
@@ -1,0 +1,6 @@
+-- Title: Unknown cities
+-- Description: OSM addresses with a city not present in CACLR
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:city" NOT IN (SELECT localite FROM addresses);

--- a/metrics/cleanup/unknown_postcodes.sql
+++ b/metrics/cleanup/unknown_postcodes.sql
@@ -1,0 +1,6 @@
+-- Title: Unknown postcodes
+-- Description: OSM addresses with a postcode not present in CACLR
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:postcode", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:postcode" NOT IN (SELECT code_postal::text FROM addresses);

--- a/metrics/cleanup/unknown_streets.sql
+++ b/metrics/cleanup/unknown_streets.sql
@@ -1,0 +1,7 @@
+-- Title: Unknown streets
+-- Description: OSM addresses referencing a street not present in CACLR
+-- include osm_potential_addresses.sql
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+FROM osm_potential_addresses
+WHERE "addr:street" NOT IN (SELECT rue FROM addresses)
+ORDER BY "addr:street";

--- a/metrics/cleanup/weird_housenumbers.sql
+++ b/metrics/cleanup/weird_housenumbers.sql
@@ -1,0 +1,3 @@
+-- Title: Weird house numbers
+-- Description: Addresses with numbers like 37AA or 1BIS
+select numero, rue, localite from addresses where numero ~ '[A-Z]{2}';

--- a/metrics/cleanup/wrong_parcel_addresses.sql
+++ b/metrics/cleanup/wrong_parcel_addresses.sql
@@ -1,0 +1,22 @@
+-- Title: Wrong parcel matches
+-- Description: OSM addresses matching CACLR but placed in a different parcel
+-- include osm_potential_addresses.sql
+select * from (SELECT
+         round(St_distance(St_centroid(osm.way), St_transform(caclr.geom, 3857))) AS dist,
+         osm.*, 
+         caclr.id_caclr_bat, 
+         St_transform(caclr.geom, 3857) AS caclr_geom, 
+         St_astext(St_shortestline(St_centroid(osm.way), St_transform(caclr.geom, 3857))) as line,
+         caclr.*,
+         parcelles.*
+FROM     osm_potential_addresses osm, 
+         addresses caclr,
+         parcelles 
+WHERE    osm."ref:caclr" IS NULL 
+AND      osm."addr:housenumber" = caclr.numero 
+AND      osm."addr:city" = caclr.localite
+AND      osm."addr:postcode" = caclr.code_postal::text 
+AND      osm."addr:street" = caclr.rue 
+and      caclr.id_parcelle = parcelles.id_parcell
+and not  st_intersects(osm.way, St_transform(parcelles.wkb_geometry, 3857))
+ORDER BY dist DESC) as foo where dist > 10;

--- a/metrics/context/duplicate_address_ids.sql
+++ b/metrics/context/duplicate_address_ids.sql
@@ -1,0 +1,8 @@
+-- Title: Duplicate CACLR IDs
+-- Description: Addresses sharing the same id_caclr_bat value
+SELECT count(*) FROM (
+    SELECT id_caclr_bat
+    FROM addresses
+    GROUP BY id_caclr_bat, numero, rue, localite
+    HAVING count(id_caclr_bat) > 1
+) AS foo;

--- a/metrics/context/localities_with_maison.sql
+++ b/metrics/context/localities_with_maison.sql
@@ -1,0 +1,8 @@
+-- Title: Maison localities
+-- Description: Number of localities where street name is 'Maison'
+SELECT count(*) FROM (
+    SELECT localite
+    FROM addresses
+    WHERE rue LIKE 'Maison'
+    GROUP BY localite
+) AS foo;

--- a/metrics/context/mixed_maison_localities.sql
+++ b/metrics/context/mixed_maison_localities.sql
@@ -1,0 +1,16 @@
+-- Title: Mixed Maison localities
+-- Description: Localities containing both 'Maison' and regular street addresses
+WITH maison AS (
+    SELECT count(numero) AS numeromaison, localite
+    FROM addresses
+    WHERE rue LIKE 'Maison'
+    GROUP BY localite
+),
+nomaison AS (
+    SELECT count(numero) AS numeronomaison, localite
+    FROM addresses
+    WHERE rue NOT LIKE 'Maison'
+    GROUP BY localite
+)
+SELECT count(*) FROM maison, nomaison
+WHERE maison.localite = nomaison.localite;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F"]
+
+[tool.sqlfluff]
+dialect = "postgres"
+exclude_rules = "L003"

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env -S uv run --script python3
+# [project]
+# dependencies = [
+#     "psycopg2-binary",
+#     "Jinja2",
+#     "matplotlib",
+# ]
+"""Generate the main dashboard as static HTML."""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import glob
+import os
+from configparser import ConfigParser
+
+import psycopg2
+from psycopg2.pool import ThreadedConnectionPool
+from jinja2 import Environment, FileSystemLoader
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+CONFIG_FILE = os.environ.get("DASHBOARD_CONFIG", "config.ini")
+
+
+def load_metrics(metric_dir: str, include_dir: str) -> list[tuple[str, str, str, str]]:
+    """Load metrics from sql files.
+
+    Returns list of (slug, title, description, sql) tuples.
+    """
+    metrics: list[tuple[str, str, str, str]] = []
+    for path in sorted(
+        glob.glob(os.path.join(metric_dir, "**", "*.sql"), recursive=True)
+    ):
+        slug = os.path.splitext(os.path.basename(path))[0]
+        with open(path) as fh:
+            lines = fh.readlines()
+
+        title = slug.replace("_", " ").title()
+        description = "[No description]"
+        sql_lines: list[str] = []
+        header = True
+        for line in lines:
+            stripped = line.strip()
+            if header and stripped.startswith("--"):
+                comment = stripped[2:].strip()
+                lower = comment.lower()
+                if lower.startswith("title:"):
+                    title = comment.split(":", 1)[1].strip()
+                elif lower.startswith("description:"):
+                    description = comment.split(":", 1)[1].strip()
+                else:
+                    # ignore other comment lines in header
+                    pass
+            else:
+                header = False
+                if stripped.lower().startswith("-- include"):
+                    parts = stripped.split()
+                    if len(parts) >= 3:
+                        inc_file = os.path.join(include_dir, parts[2])
+                        with open(inc_file) as inc:
+                            sql_lines.append(inc.read())
+                    continue
+                sql_lines.append(line)
+
+        sql = "".join(sql_lines).strip()
+        metrics.append((slug, title, description, sql))
+    return metrics
+
+
+class Dashboard:
+    def __init__(self, config: ConfigParser) -> None:
+        self.config = config
+        self.output_dir = self.config.get("paths", "output_dir", fallback="output")
+        self.history_dir = self.config.get("paths", "history_dir", fallback="history")
+        os.makedirs(self.output_dir, exist_ok=True)
+        os.makedirs(self.history_dir, exist_ok=True)
+        os.makedirs(os.path.join(self.output_dir, "img"), exist_ok=True)
+        self.env = Environment(loader=FileSystemLoader("templates"))
+        self.conn_params = {
+            "port": self.config.getint("database", "port", fallback=5432),
+            "dbname": self.config.get("database", "dbname"),
+            "user": self.config.get("database", "user"),
+        }
+        host = self.config.get("database", "host", fallback="")
+        if host:
+            self.conn_params["host"] = host
+        password = self.config.get("database", "password", fallback="")
+        if password:
+            self.conn_params["password"] = password
+        self.pool = ThreadedConnectionPool(1, 8, **self.conn_params)
+
+    def run(self) -> None:
+        metric_dir = self.config.get("paths", "metrics_dir", fallback="metrics")
+        include_dir = self.config.get("paths", "includes_dir", fallback="includes")
+        metrics = []
+        metric_defs = list(load_metrics(metric_dir, include_dir))
+        results: list[tuple[str, str, str, list[tuple], list[str]]] = []
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        with ThreadPoolExecutor() as exe:
+            futs = {
+                exe.submit(self._fetch_rows, sql): (slug, title, desc)
+                for slug, title, desc, sql in metric_defs
+            }
+            for fut in as_completed(futs):
+                slug, title, desc = futs[fut]
+                rows, headers = fut.result()
+                results.append((slug, title, desc, rows, headers))
+
+        for slug, title, desc, rows, headers in sorted(results):
+            if len(rows) == 1 and len(headers) == 1:
+                value = int(rows[0][0] or 0)
+                details = None
+            else:
+                value = len(rows)
+                details = {
+                    "rows": rows,
+                    "headers": headers,
+                    "josm": self._josm_link(rows, headers),
+                }
+            self._update_history(slug, value)
+            graph = self._plot_history(slug)
+            metrics.append(
+                {
+                    "slug": slug,
+                    "title": title,
+                    "description": desc,
+                    "value": value,
+                    "graph": graph,
+                    "details": details,
+                }
+            )
+        template = self.env.get_template("dashboard.html")
+        html = template.render(metrics=metrics)
+        with open(os.path.join(self.output_dir, "index.html"), "w") as fh:
+            fh.write(html)
+        self.pool.closeall()
+
+    def _fetch_rows(self, sql: str) -> tuple[list[tuple], list[str]]:
+        conn = self.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql)
+                rows = cur.fetchall()
+                headers = [d[0] for d in cur.description]
+        finally:
+            self.pool.putconn(conn)
+        return rows, headers
+
+    def _update_history(self, slug: str, value: int) -> None:
+        path = os.path.join(self.history_dir, f"{slug}.csv")
+        is_new = not os.path.exists(path)
+        with open(path, "a", newline="") as fh:
+            writer = csv.writer(fh)
+            if is_new:
+                writer.writerow(["date", "value"])
+            writer.writerow([dt.date.today().isoformat(), value])
+
+    def _plot_history(self, slug: str) -> str | None:
+        path = os.path.join(self.history_dir, f"{slug}.csv")
+        if not os.path.exists(path):
+            return None
+        dates, values = [], []
+        try:
+            with open(path) as fh:
+                reader = csv.DictReader(fh)
+                for row in reader:
+                    dates.append(dt.datetime.fromisoformat(row["date"]))
+                    values.append(int(row["value"]))
+        except Exception:
+            return None
+        if len(values) < 2:
+            return None
+        plt.figure(figsize=(2.5, 1))
+        plt.plot(dates, values, marker="o", linewidth=1, markersize=2)
+        plt.xticks([])
+        plt.yticks([])
+        plt.tight_layout()
+        img_path = os.path.join(self.output_dir, "img", f"{slug}.png")
+        plt.savefig(img_path)
+        plt.close()
+        return os.path.relpath(img_path, self.output_dir)
+
+    def _josm_link(self, rows: list[tuple], headers: list[str]) -> str | None:
+        if "osm_id" not in headers or "osm_type" not in headers:
+            return None
+        id_idx = headers.index("osm_id")
+        type_idx = headers.index("osm_type")
+        objects = []
+        for row in rows:
+            prefix = row[type_idx][0]
+            objects.append(f"{prefix}{row[id_idx]}")
+        url_tpl = self.config.get("general", "josm_remote_url")
+        return url_tpl.format(object_ids=",".join(objects))
+
+
+def main() -> None:
+    config = ConfigParser()
+    config.read(CONFIG_FILE)
+    Dashboard(config).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
+</head>
+<body>
+<section class="section">
+<div class="container">
+{% block content %}{% endblock %}
+</div>
+{% block extra_scripts %}{% endblock %}
+</section>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="title">Luxembourg Address Conflation Dashboard</h1>
+<table class="table is-striped is-hoverable">
+<thead>
+<tr><th>Metric</th><th>Value</th><th>Trend</th></tr>
+</thead>
+<tbody>
+{% for metric in metrics %}
+<tr class="toggle" data-target="d-{{ metric.slug }}">
+  <td><span class="icon">&#9654;</span> {{ metric.title }}</td>
+  <td>{{ metric.value }}</td>
+  <td>{% if metric.graph %}<img src="{{ metric.graph }}" alt="trend" style="height:40px">{% endif %}</td>
+</tr>
+<tr id="d-{{ metric.slug }}" class="is-hidden">
+  <td colspan="3">
+    <p>{{ metric.description }}</p>
+    {% if metric.details %}
+    {% if metric.details.josm %}<p><a href="{{ metric.details.josm }}">Load in JOSM</a></p>{% endif %}
+    <table class="table is-bordered is-narrow is-fullwidth">
+      <thead><tr>{% for h in metric.details.headers %}<th>{{ h }}</th>{% endfor %}</tr></thead>
+      <tbody>
+      {% for row in metric.details.rows %}
+      <tr>{% for cell in row %}<td>{{ cell }}</td>{% endfor %}</tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
+  </td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+{% endblock %}
+{% block extra_scripts %}
+<script>
+document.querySelectorAll('.toggle').forEach(tr => {
+  tr.addEventListener('click', () => {
+    const target = document.getElementById(tr.dataset.target);
+    if (target.classList.contains('is-hidden')) {
+      target.classList.remove('is-hidden');
+      tr.querySelector('.icon').textContent = '\u25BC';
+    } else {
+      target.classList.add('is-hidden');
+      tr.querySelector('.icon').textContent = '\u25B6';
+    }
+  });
+});
+</script>
+{% endblock %}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,10 @@
+from scripts.generate_dashboard import load_metrics
+
+
+def test_load_metrics():
+    metrics = load_metrics("metrics", "includes")
+    assert metrics
+    for slug, title, desc, sql in metrics:
+        assert slug and sql
+        assert isinstance(title, str)
+        assert isinstance(desc, str)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,20 @@
+from jinja2 import Environment, FileSystemLoader
+
+
+def test_dashboard_template():
+    env = Environment(loader=FileSystemLoader("templates"))
+    tpl = env.get_template("dashboard.html")
+    html = tpl.render(
+        metrics=[
+            {
+                "slug": "test",
+                "title": "Test",
+                "description": "desc",
+                "value": 1,
+                "graph": None,
+                "details": None,
+            }
+        ]
+    )
+    assert "Test" in html
+    assert "table" in html


### PR DESCRIPTION
## Summary
- organize metric queries into `cleanup/` and `context/`
- add metrics for invalid street/postcode pairs and unknown postcodes
- reuse database connections via a connection pool
- load metric SQL recursively and handle malformed history files
- document schema, tests and formatting in the README
- introduce formatting checks via GitHub Actions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6850c339eb68832fb9c5a90d299a60a7