### PR TITLE
Use uv for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,6 @@ in JOSM" link is offered. The script uses an
 [uv](https://github.com/astral-sh/uv) shebang to automatically install its Python dependencies.
 Queries run concurrently so the dashboard builds quickly.
 
-### Test setup
-
-Create a virtual environment and install the dependencies from
-`pyproject.toml`:
-
-```bash
-uv venv
-uv sync
-```
-
 ### Running the tests
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,10 +31,20 @@ in JOSM" link is offered. The script uses an
 [uv](https://github.com/astral-sh/uv) shebang to automatically install its Python dependencies.
 Queries run concurrently so the dashboard builds quickly.
 
+### Test setup
+
+Create a virtual environment and install the dependencies from
+`pyproject.toml`:
+
+```bash
+uv venv
+uv sync
+```
+
 ### Running the tests
 
 ```
-pytest
+uv run pytest
 ```
 
 ### Code style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,13 @@ select = ["E", "F"]
 [tool.sqlfluff]
 dialect = "postgres"
 exclude_rules = "L003"
+
+[project]
+name = "osm-caclr-address-dashboard"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = [
+    "psycopg2-binary",
+    "Jinja2",
+    "matplotlib",
+]

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1,10 +1,4 @@
-#!/usr/bin/env -S uv run --script python3
-# [project]
-# dependencies = [
-#     "psycopg2-binary",
-#     "Jinja2",
-#     "matplotlib",
-# ]
+#!/usr/bin/env -S uv run
 """Generate the main dashboard as static HTML."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- use uv run shebang for generate_dashboard.py
- document uv sync + uv run workflow in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uv run --with pytest python -m pytest -q`
- `./scripts/generate_dashboard.py` *(fails to connect to DB)*

------
https://chatgpt.com/codex/tasks/task_e_6851b2a6f79c832fbf423318126f4f6e