### PR TITLE
Update DB settings and connection pool

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -2,10 +2,11 @@
 # leave host empty to use the local socket
 host=
 port=5432
-dbname=caclr
-user=osm
+dbname=osmlu
+user=stereo
 # empty password means libpq will rely on your pg_hba.conf
 password=
+max_connections=32
 
 [paths]
 output_dir=output

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -87,7 +87,8 @@ class Dashboard:
         password = self.config.get("database", "password", fallback="")
         if password:
             self.conn_params["password"] = password
-        self.pool = ThreadedConnectionPool(1, 8, **self.conn_params)
+        max_conn = self.config.getint("database", "max_connections", fallback=32)
+        self.pool = ThreadedConnectionPool(1, max_conn, **self.conn_params)
 
     def run(self) -> None:
         metric_dir = self.config.get("paths", "metrics_dir", fallback="metrics")


### PR DESCRIPTION
## Summary
- set the default DB name to `osmlu`
- set the default user to `stereo`
- allow configuring connection pool size with `max_connections`

## Testing
- `pip install -q psycopg2-binary Jinja2 matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851c0e032e4832f8bad2b365a8e240c