### PR TITLE
Improve metric SQL validation

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,6 @@
+import glob
+import os
+
 from scripts.generate_dashboard import load_metrics
 
 
@@ -8,3 +11,25 @@ def test_load_metrics():
         assert slug and sql
         assert isinstance(title, str)
         assert isinstance(desc, str)
+
+
+def test_osm_potential_addresses_imports():
+    for path in glob.glob(os.path.join("metrics", "**", "*.sql"), recursive=True):
+        with open(path) as fh:
+            content = fh.read()
+        if "osm_potential_addresses" in content:
+            lower = content.lower()
+            assert (
+                "-- include osm_potential_addresses.sql" in lower
+                or "with osm_potential_addresses" in lower
+            ), f"{path} missing osm_potential_addresses snippet"
+
+
+def test_load_metrics_includes_osm_addresses():
+    metric_map = {slug: sql for slug, _, _, sql in load_metrics("metrics", "includes")}
+    for path in glob.glob(os.path.join("metrics", "**", "*.sql"), recursive=True):
+        with open(path) as fh:
+            content = fh.read()
+        slug = os.path.splitext(os.path.basename(path))[0]
+        if "-- include osm_potential_addresses.sql" in content.lower():
+            assert "with osm_potential_addresses" in metric_map[slug].lower()


### PR DESCRIPTION
## Summary
- remove automatic injection of `osm_potential_addresses` CTE
- show metric slug when SQL execution fails
- test that metric SQL files import the `osm_potential_addresses` CTE when referenced
- handle `-- include` lines even if they appear inside the metric header
- ensure loaded SQL actually contains the CTE content

## Testing
- `pip install --quiet psycopg2-binary Jinja2 matplotlib`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851c55e6b18832fb8040b32f446fa21