### PR TITLE
Style zero result rows

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,17 @@
     <meta charset="utf-8" />
     <title>{{ title }}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
+    <style>
+    .zero-result td {
+        color: #666;
+        font-size: 0.9em;
+    }
+    @media (prefers-color-scheme: dark) {
+        .zero-result td {
+            color: #aaa;
+        }
+    }
+    </style>
 </head>
 <body>
 <section class="section">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -10,7 +10,7 @@
 </thead>
 <tbody>
 {% for metric in metrics %}
-<tr class="toggle" data-target="d-{{ metric.slug }}" data-value="{{ metric.value }}">
+<tr class="toggle{% if metric.value == 0 %} zero-result{% endif %}" data-target="d-{{ metric.slug }}" data-value="{{ metric.value }}">
   <td><span class="icon">&#9654;</span> {{ metric.title }}</td>
   <td>{{ metric.value }}</td>
   <td>{% if metric.graph %}<img src="{{ metric.graph }}" alt="trend" style="height:40px">{% endif %}</td>
@@ -88,9 +88,9 @@ document.addEventListener('DOMContentLoaded', () => {
     hideZero = !hideZero;
     btnZero.textContent = hideZero ? 'Show Zero Results' : 'Hide Zero Results';
     document.querySelectorAll('#metrics-table tbody tr.toggle').forEach(row => {
-      const val = parseInt(row.dataset.value, 10) || 0;
+      const isZero = row.classList.contains('zero-result');
       const detail = document.getElementById(row.dataset.target);
-      if (hideZero && val === 0) {
+      if (hideZero && isZero) {
         row.style.display = 'none';
         detail.style.display = 'none';
       } else {
@@ -134,9 +134,9 @@ btnZero.addEventListener('click', () => {
   hideZero = !hideZero;
   btnZero.textContent = hideZero ? 'Show Zero Results' : 'Hide Zero Results';
   document.querySelectorAll('tbody tr.toggle').forEach(row => {
-    const val = parseInt(row.dataset.value, 10) || 0;
+    const isZero = row.classList.contains('zero-result');
     const detail = document.getElementById(row.dataset.target);
-    if (hideZero && val === 0) {
+    if (hideZero && isZero) {
       row.style.display = 'none';
       detail.style.display = 'none';
     } else {


### PR DESCRIPTION
## Summary
- make 0-result rows smaller and grey
- keep text visible in light and dark modes
- hide rows via zero-result class

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c6cdf9100832fb5ce9c29112bd240