### PR TITLE
Update dashboard metrics

### DIFF
--- a/metrics/caclr_mismatch.sql
+++ b/metrics/caclr_mismatch.sql
@@ -1,7 +1,17 @@
 -- Title: CACLR mismatch
 -- Description: Addresses tagged with ref:caclr where the street or city differs from the official record
 -- include osm_potential_addresses.sql
-SELECT count(*) FROM osm_potential_addresses, addresses
-WHERE osm_potential_addresses."ref:caclr" = addresses.id_caclr_bat
-  AND (osm_potential_addresses."addr:street" != addresses.rue
-    OR osm_potential_addresses."addr:city" != addresses.localite);
+SELECT
+    osm_id,
+    osm_type,
+    osm_potential_addresses."addr:housenumber",
+    osm_potential_addresses."addr:street" AS osm_street,
+    addresses.rue AS caclr_street,
+    osm_potential_addresses."addr:city" AS osm_city,
+    addresses.localite AS caclr_city
+FROM osm_potential_addresses
+JOIN addresses ON osm_potential_addresses."ref:caclr" = addresses.id_caclr_bat
+WHERE osm_potential_addresses."addr:street" != addresses.rue
+   OR osm_potential_addresses."addr:city" != addresses.localite
+ORDER BY addresses.localite, addresses.rue,
+         osm_potential_addresses."addr:housenumber";

--- a/metrics/duplicate_address_ids.sql
+++ b/metrics/duplicate_address_ids.sql
@@ -1,8 +1,11 @@
--- Title: Duplicate CACLR IDs
+-- Title: Context: Addresses without housenumber not in OSM
 -- Description: Context: Addresses in CACLR sharing the same id_caclr_bat value, e.g. when a parcel got split and both parts get the old address
-SELECT count(*) FROM (
-    SELECT id_caclr_bat
-    FROM addresses
-    GROUP BY id_caclr_bat, numero, rue, localite
-    HAVING count(id_caclr_bat) > 1
-) AS foo;
+SELECT id_caclr_bat,
+       numero,
+       rue,
+       localite,
+       COUNT(*) AS occurrences
+FROM addresses
+GROUP BY id_caclr_bat, numero, rue, localite
+HAVING COUNT(id_caclr_bat) > 1
+ORDER BY occurrences DESC, id_caclr_bat;

--- a/metrics/far_match_addresses.sql
+++ b/metrics/far_match_addresses.sql
@@ -1,13 +1,13 @@
 -- Title: Far matches
 -- Description: OSM addresses matching CACLR but located more than 30m away
     WITH osm_potential_addresses AS (
-        SELECT osm_id, osm_user, concat('https://osm.org/way/' , osm_id) as url, concat('w' , osm_id) as josmuid, osm_timestamp, name, "addr:housenumber", "addr:street", "addr:postcode", "addr:city", "addr:country", "ref:caclr", "note", "note:caclr", "fixme", way
+        SELECT osm_id, 'way' AS osm_type, osm_user, concat('https://osm.org/way/' , osm_id) as url, concat('w' , osm_id) as josmuid, osm_timestamp, name, "addr:housenumber", "addr:street", "addr:postcode", "addr:city", "addr:country", "ref:caclr", "note", "note:caclr", "fixme", way
         FROM planet_osm_polygon
         WHERE "addr:housenumber" IS NOT NULL
           AND "addr:street" IS NOT NULL
           AND "addr:postcode" IS NOT NULL
           AND "addr:city" IS NOT NULL
-        UNION SELECT osm_id, osm_user,  concat('https://osm.org/node/' , osm_id) as url, concat('n' , osm_id) as josmuid, osm_timestamp, name, "addr:housenumber", "addr:street", "addr:postcode", "addr:city", "addr:country", "ref:caclr", "note", "note:caclr", "fixme", way
+        UNION SELECT osm_id, 'node' AS osm_type, osm_user,  concat('https://osm.org/node/' , osm_id) as url, concat('n' , osm_id) as josmuid, osm_timestamp, name, "addr:housenumber", "addr:street", "addr:postcode", "addr:city", "addr:country", "ref:caclr", "note", "note:caclr", "fixme", way
         FROM planet_osm_point
         WHERE "addr:housenumber" IS NOT NULL
           AND "addr:street" IS NOT NULL

--- a/metrics/invalid_street_postcode.sql
+++ b/metrics/invalid_street_postcode.sql
@@ -1,7 +1,7 @@
 -- Title: Invalid street/postcode
 -- Description: Street and postcode pairs that do not exist in CACLR
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:postcode", "addr:city"
+SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:postcode", "addr:city", "ref:caclr", "note:caclr"
 FROM osm_potential_addresses
 WHERE ("addr:street", "addr:postcode") NOT IN (
     SELECT rue, code_postal::text FROM addresses

--- a/metrics/mixed_maison_localities.sql
+++ b/metrics/mixed_maison_localities.sql
@@ -12,5 +12,7 @@ nomaison AS (
     WHERE rue NOT LIKE 'Maison'
     GROUP BY localite
 )
-SELECT count(*) FROM maison, nomaison
-WHERE maison.localite = nomaison.localite;
+SELECT maison.localite
+FROM maison
+JOIN nomaison ON maison.localite = nomaison.localite
+ORDER BY maison.localite;

--- a/metrics/wrong_parcel_addresses.sql
+++ b/metrics/wrong_parcel_addresses.sql
@@ -1,13 +1,13 @@
 -- Title: Wrong parcel matches
 -- Description: OSM addresses matching CACLR but placed in a different parcel
     WITH osm_potential_addresses AS (
-        SELECT osm_id, osm_user, concat('https://osm.org/way/' , osm_id) as url, concat('w' , osm_id) as josmuid, osm_timestamp, name, "addr:housenumber", "addr:street", "addr:postcode", "addr:city", "addr:country", "ref:caclr", "note", "note:caclr", "fixme", way
+        SELECT osm_id, 'way' AS osm_type, osm_user, concat('https://osm.org/way/' , osm_id) as url, concat('w' , osm_id) as josmuid, osm_timestamp, name, "addr:housenumber", "addr:street", "addr:postcode", "addr:city", "addr:country", "ref:caclr", "note", "note:caclr", "fixme", way
         FROM planet_osm_polygon
         WHERE "addr:housenumber" IS NOT NULL
           AND "addr:street" IS NOT NULL
           AND "addr:postcode" IS NOT NULL
           AND "addr:city" IS NOT NULL
-        UNION SELECT osm_id, osm_user,  concat('https://osm.org/node/' , osm_id) as url, concat('n' , osm_id) as josmuid, osm_timestamp, name, "addr:housenumber", "addr:street", "addr:postcode", "addr:city", "addr:country", "ref:caclr", "note", "note:caclr", "fixme", way
+        UNION SELECT osm_id, 'node' AS osm_type, osm_user,  concat('https://osm.org/node/' , osm_id) as url, concat('n' , osm_id) as josmuid, osm_timestamp, name, "addr:housenumber", "addr:street", "addr:postcode", "addr:city", "addr:country", "ref:caclr", "note", "note:caclr", "fixme", way
         FROM planet_osm_point
         WHERE "addr:housenumber" IS NOT NULL
           AND "addr:street" IS NOT NULL


### PR DESCRIPTION
## Summary
- switch `duplicate_address_ids` to context metric
- report rows for CACLR mismatch, duplicate address IDs, and mixed Maison localities
- extend invalid street/postcode with CACLR refs
- add `osm_type` so far match and wrong parcel metrics can be loaded in JOSM

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uv run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685c729fed38832fa427f96e218c0ee7