### PR TITLE
Enhance dashboard links and metrics

### DIFF
--- a/includes/osm_potential_addresses.sql
+++ b/includes/osm_potential_addresses.sql
@@ -1,5 +1,7 @@
 WITH osm_potential_addresses AS (
     SELECT osm_id, 'node' AS osm_type,
+           concat('https://osm.org/node/', osm_id) AS url,
+           concat('n', osm_id) AS josmuid,
            "addr:housenumber", "addr:street", "addr:postcode",
            "addr:city", "ref:caclr", "note:caclr"
     FROM planet_osm_point
@@ -9,6 +11,8 @@ WITH osm_potential_addresses AS (
       AND "addr:city" IS NOT NULL
     UNION
     SELECT osm_id, 'way' AS osm_type,
+           concat('https://osm.org/way/', osm_id) AS url,
+           concat('w', osm_id) AS josmuid,
            "addr:housenumber", "addr:street", "addr:postcode",
            "addr:city", "ref:caclr", "note:caclr"
     FROM planet_osm_polygon

--- a/metrics/addr_interpolation.sql
+++ b/metrics/addr_interpolation.sql
@@ -1,5 +1,11 @@
 -- Title: addr:interpolation ways
 -- Description: Ways tagged with addr:interpolation
-SELECT osm_id, 'way' AS osm_type, "addr:interpolation"
+SELECT osm_id,
+       'way' AS osm_type,
+       concat('https://osm.org/way/', osm_id) AS url,
+       concat('w', osm_id) AS josmuid,
+       "addr:interpolation",
+       "ref:caclr",
+       "note:caclr"
 FROM planet_osm_line
 WHERE "addr:interpolation" IS NOT NULL;

--- a/metrics/caclr_mismatch.sql
+++ b/metrics/caclr_mismatch.sql
@@ -4,11 +4,15 @@
 SELECT
     osm_id,
     osm_type,
+    url,
+    josmuid,
     osm_potential_addresses."addr:housenumber",
     osm_potential_addresses."addr:street" AS osm_street,
     addresses.rue AS caclr_street,
     osm_potential_addresses."addr:city" AS osm_city,
-    addresses.localite AS caclr_city
+    addresses.localite AS caclr_city,
+    osm_potential_addresses."ref:caclr",
+    osm_potential_addresses."note:caclr"
 FROM osm_potential_addresses
 JOIN addresses ON osm_potential_addresses."ref:caclr" = addresses.id_caclr_bat
 WHERE osm_potential_addresses."addr:street" != addresses.rue

--- a/metrics/far_match_addresses.sql
+++ b/metrics/far_match_addresses.sql
@@ -19,9 +19,9 @@
 
 select * from (SELECT   osm.*,
          caclr.id_caclr_bat,
-         St_distance(St_centroid(osm.way), St_transform(caclr.geom, 3857)) AS dist,
-         St_transform(caclr.geom, 3857)                                    AS caclr_geom,
-         St_astext(St_shortestline(St_centroid(osm.way), St_transform(caclr.geom, 3857))) as line
+         St_distance(St_transform(St_centroid(osm.way), 2169), St_transform(caclr.geom, 2169)) AS dist,
+         St_transform(caclr.geom, 2169) AS caclr_geom,
+         St_astext(St_shortestline(St_transform(St_centroid(osm.way), 2169), St_transform(caclr.geom, 2169))) as line
 FROM     osm_potential_addresses osm,
          addresses caclr
 WHERE    osm."ref:caclr" IS NULL

--- a/metrics/housenumber_comma.sql
+++ b/metrics/housenumber_comma.sql
@@ -1,6 +1,14 @@
 -- Title: Comma in housenumbers
 -- Description: Housenumbers containing commas
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:housenumber" ~ ',';

--- a/metrics/housenumber_invalid_format.sql
+++ b/metrics/housenumber_invalid_format.sql
@@ -2,17 +2,29 @@
 -- Description: OSM housenumbers not matching the expected pattern
 WITH osm_potential_addresses AS (
     SELECT osm_id, 'node' AS osm_type,
+           concat('https://osm.org/node/', osm_id) AS url,
+           concat('n', osm_id) AS josmuid,
            "addr:housenumber", "addr:street", "addr:postcode",
-           "addr:city"
+           "addr:city", "ref:caclr", "note:caclr"
     FROM planet_osm_point
     WHERE "addr:housenumber" IS NOT NULL
     UNION
     SELECT osm_id, 'way' AS osm_type,
+           concat('https://osm.org/way/', osm_id) AS url,
+           concat('w', osm_id) AS josmuid,
            "addr:housenumber", "addr:street", "addr:postcode",
-           "addr:city"
+           "addr:city", "ref:caclr", "note:caclr"
     FROM planet_osm_polygon
     WHERE "addr:housenumber" IS NOT NULL
 )
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:housenumber" !~ '^[1-9][0-9]{0,2}[A-Z]{0,3}(-*[1-9][0-9]{0,2}[A-Z]{0,3}){0,4}$';

--- a/metrics/housenumber_leading_zero.sql
+++ b/metrics/housenumber_leading_zero.sql
@@ -1,6 +1,14 @@
 -- Title: Leading zero housenumbers
 -- Description: Housenumbers starting with zero
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:housenumber" ~ '^0';

--- a/metrics/housenumber_lowercase.sql
+++ b/metrics/housenumber_lowercase.sql
@@ -1,6 +1,14 @@
 -- Title: Lowercase housenumbers
 -- Description: Housenumbers containing lowercase letters
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:housenumber" ~ '[a-z]';

--- a/metrics/housenumber_not_numeric.sql
+++ b/metrics/housenumber_not_numeric.sql
@@ -1,6 +1,14 @@
 -- Title: Non-numeric housenumbers
 -- Description: Housenumbers starting with letters
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:housenumber" ~ '^[A-Z]';

--- a/metrics/housenumber_semicolon.sql
+++ b/metrics/housenumber_semicolon.sql
@@ -1,6 +1,14 @@
 -- Title: Semicolon in housenumbers
 -- Description: Housenumbers containing semicolons
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:housenumber" ~ ';';

--- a/metrics/housenumber_slash.sql
+++ b/metrics/housenumber_slash.sql
@@ -1,6 +1,14 @@
 -- Title: Slash in housenumbers
 -- Description: Housenumbers containing slashes
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:housenumber" ~ '/';

--- a/metrics/housenumber_whitespace.sql
+++ b/metrics/housenumber_whitespace.sql
@@ -1,6 +1,14 @@
 -- Title: Whitespace in housenumbers
 -- Description: Housenumbers containing spaces
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:housenumber" ~ ' ';

--- a/metrics/invalid_street_postcode.sql
+++ b/metrics/invalid_street_postcode.sql
@@ -1,7 +1,16 @@
 -- Title: Invalid street/postcode
 -- Description: Street and postcode pairs that do not exist in CACLR
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:postcode", "addr:city", "ref:caclr", "note:caclr"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:postcode",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE ("addr:street", "addr:postcode") NOT IN (
     SELECT rue, code_postal::text FROM addresses

--- a/metrics/localities_with_maison.sql
+++ b/metrics/localities_with_maison.sql
@@ -1,8 +1,7 @@
 -- Title: Maison localities
 -- Description: Context: Number of localities in CACLR containing street name 'Maison'
-SELECT count(*) FROM (
-    SELECT localite
-    FROM addresses
-    WHERE rue LIKE 'Maison'
-    GROUP BY localite
-) AS foo;
+SELECT localite, COUNT(*) AS count
+FROM addresses
+WHERE rue LIKE 'Maison'
+GROUP BY localite
+ORDER BY count DESC, localite;

--- a/metrics/missing_caclr_reference.sql
+++ b/metrics/missing_caclr_reference.sql
@@ -1,9 +1,17 @@
 -- Title: Missing CACLR reference
 -- Description: ref:caclr values present in OSM but not in the official dataset
 -- include osm_potential_addresses.sql
-SELECT count(*) FROM (
-    SELECT DISTINCT "ref:caclr" FROM osm_potential_addresses
-    WHERE "ref:caclr" NOT IN ('missing', 'wrong')
-    EXCEPT
-    SELECT id_caclr_bat FROM addresses
-) AS foo;
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:postcode",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
+FROM osm_potential_addresses
+WHERE "ref:caclr" NOT IN ('missing', 'wrong')
+  AND "ref:caclr" NOT IN (SELECT id_caclr_bat FROM addresses)
+ORDER BY "addr:city", "addr:street", "addr:housenumber";

--- a/metrics/missing_city.sql
+++ b/metrics/missing_city.sql
@@ -1,9 +1,23 @@
 -- Title: Missing city
 -- Description: OSM addresses lacking a city tag
-SELECT osm_id, 'node' AS osm_type, "addr:housenumber", "addr:street"
+SELECT osm_id,
+       'node' AS osm_type,
+       concat('https://osm.org/node/', osm_id) AS url,
+       concat('n', osm_id) AS josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "ref:caclr",
+       "note:caclr"
 FROM planet_osm_point
 WHERE "addr:housenumber" IS NOT NULL AND "addr:city" IS NULL
 UNION
-SELECT osm_id, 'way' AS osm_type, "addr:housenumber", "addr:street"
+SELECT osm_id,
+       'way' AS osm_type,
+       concat('https://osm.org/way/', osm_id) AS url,
+       concat('w', osm_id) AS josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "ref:caclr",
+       "note:caclr"
 FROM planet_osm_polygon
 WHERE "addr:housenumber" IS NOT NULL AND "addr:city" IS NULL;

--- a/metrics/missing_postcode.sql
+++ b/metrics/missing_postcode.sql
@@ -1,12 +1,28 @@
 -- Title: Missing postcode
 -- Description: OSM addresses with housenumber and street but no postcode
-SELECT osm_id, 'node' AS osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       'node' AS osm_type,
+       concat('https://osm.org/node/', osm_id) AS url,
+       concat('n', osm_id) AS josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM planet_osm_point
 WHERE "addr:housenumber" IS NOT NULL
   AND "addr:street" IS NOT NULL
   AND "addr:postcode" IS NULL
 UNION
-SELECT osm_id, 'way' AS osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       'way' AS osm_type,
+       concat('https://osm.org/way/', osm_id) AS url,
+       concat('w', osm_id) AS josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM planet_osm_polygon
 WHERE "addr:housenumber" IS NOT NULL
   AND "addr:street" IS NOT NULL

--- a/metrics/no_match_in_caclr.sql
+++ b/metrics/no_match_in_caclr.sql
@@ -3,25 +3,28 @@
 WITH osm_potential_addresses AS (
     SELECT osm_id, 'node' AS osm_type, osm_user, name,
            "addr:housenumber", "addr:street", "addr:postcode",
-           "addr:city", "ref:caclr", way
+           "addr:city", "ref:caclr", "note:caclr", way
     FROM planet_osm_point
     WHERE "addr:street" IS NOT NULL
     UNION
     SELECT osm_id, 'way' AS osm_type, osm_user, name,
            "addr:housenumber", "addr:street", "addr:postcode",
-           "addr:city", "ref:caclr", way
+           "addr:city", "ref:caclr", "note:caclr", way
     FROM planet_osm_polygon
     WHERE "addr:street" IS NOT NULL
 )
-SELECT osm_id, osm_type, url, osm_user,
+SELECT osm_id, osm_type, url, josmuid, osm_user,
        "addr:housenumber" AS numero,
        "addr:street" AS rue,
        "addr:postcode" AS codepostal,
-       "addr:city" AS localite
+       "addr:city" AS localite,
+       "ref:caclr",
+       "note:caclr"
 FROM (
     SELECT osm_id, osm_type, osm_user, name, "addr:housenumber",
-           "addr:street", "addr:postcode", "addr:city", "ref:caclr",
-           concat('https://osm.org/', CASE WHEN osm_type='node' THEN 'node/' ELSE 'way/' END, osm_id) AS url
+           "addr:street", "addr:postcode", "addr:city", "ref:caclr", "note:caclr",
+           concat('https://osm.org/', CASE WHEN osm_type='node' THEN 'node/' ELSE 'way/' END, osm_id) AS url,
+           concat(CASE WHEN osm_type='node' THEN 'n' ELSE 'w' END, osm_id) AS josmuid
     FROM osm_potential_addresses
 ) AS osm
 LEFT JOIN addresses ON addresses.numero = osm."addr:housenumber" AND addresses.localite = osm."addr:city" AND addresses.rue = osm."addr:street"

--- a/metrics/osm_no_number_or_name.sql
+++ b/metrics/osm_no_number_or_name.sql
@@ -2,15 +2,27 @@
 -- Description: Objects with addr:street but neither housenumber nor housename
 WITH osm_potential_addresses AS (
     SELECT osm_id, 'node' AS osm_type,
-           "addr:housenumber", "addr:housename", "addr:street"
+           concat('https://osm.org/node/', osm_id) AS url,
+           concat('n', osm_id) AS josmuid,
+           "addr:housenumber", "addr:housename", "addr:street",
+           "ref:caclr", "note:caclr"
     FROM planet_osm_point
     WHERE "addr:street" IS NOT NULL
     UNION
     SELECT osm_id, 'way' AS osm_type,
-           "addr:housenumber", "addr:housename", "addr:street"
+           concat('https://osm.org/way/', osm_id) AS url,
+           concat('w', osm_id) AS josmuid,
+           "addr:housenumber", "addr:housename", "addr:street",
+           "ref:caclr", "note:caclr"
     FROM planet_osm_polygon
     WHERE "addr:street" IS NOT NULL
 )
-SELECT osm_id, osm_type, "addr:street"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:street",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:housenumber" IS NULL AND "addr:housename" IS NULL;

--- a/metrics/postcode_prefix_l.sql
+++ b/metrics/postcode_prefix_l.sql
@@ -1,5 +1,12 @@
 -- Title: Postcodes with L prefix
 -- Description: Addresses with postcode starting with L or L-
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:postcode" FROM osm_potential_addresses
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:postcode",
+       "ref:caclr",
+       "note:caclr"
+FROM osm_potential_addresses
 WHERE "addr:postcode" ILIKE 'L%' OR "addr:postcode" ILIKE 'L-%';

--- a/metrics/ref_missing_wrong.sql
+++ b/metrics/ref_missing_wrong.sql
@@ -21,6 +21,7 @@
 SELECT
          osm.osm_id,
          osm.url,
+         osm.josmuid,
          osm."addr:housenumber",
          caclr.numero,
          osm."addr:street",
@@ -29,6 +30,7 @@ SELECT
          caclr.localite,
          osm."note:caclr",
          osm."note",
+         osm."ref:caclr",
          caclr.id_caclr_bat
 FROM     osm_potential_addresses osm,
          addresses caclr

--- a/metrics/streets_missing_in_osm.sql
+++ b/metrics/streets_missing_in_osm.sql
@@ -1,0 +1,14 @@
+-- Title: Streets missing in OSM
+-- Description: Street names present in CACLR but absent from OSM
+SELECT rue AS street,
+       COUNT(*) AS address_count
+FROM addresses
+WHERE rue NOT IN (
+    SELECT DISTINCT "addr:street" FROM planet_osm_point WHERE "addr:street" IS NOT NULL
+    UNION
+    SELECT DISTINCT "addr:street" FROM planet_osm_polygon WHERE "addr:street" IS NOT NULL
+    UNION
+    SELECT DISTINCT name FROM planet_osm_line WHERE name IS NOT NULL
+)
+GROUP BY rue
+ORDER BY rue;

--- a/metrics/unclosed_address_ways.sql
+++ b/metrics/unclosed_address_ways.sql
@@ -1,6 +1,13 @@
 -- Title: Addressed open ways
 -- Description: Ways with address tags that are not closed
-SELECT osm_id, 'way' AS osm_type, "addr:housenumber", "addr:street"
+SELECT osm_id,
+       'way' AS osm_type,
+       concat('https://osm.org/way/', osm_id) AS url,
+       concat('w', osm_id) AS josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "ref:caclr",
+       "note:caclr"
 FROM planet_osm_line
 WHERE ("addr:housenumber" IS NOT NULL OR "addr:street" IS NOT NULL OR
        "addr:city" IS NOT NULL OR "addr:postcode" IS NOT NULL)

--- a/metrics/unknown_cities.sql
+++ b/metrics/unknown_cities.sql
@@ -1,6 +1,14 @@
 -- Title: Unknown cities
 -- Description: OSM addresses with a city not present in CACLR
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:city" NOT IN (SELECT localite FROM addresses);

--- a/metrics/unknown_postcodes.sql
+++ b/metrics/unknown_postcodes.sql
@@ -1,6 +1,15 @@
 -- Title: Unknown postcodes
 -- Description: OSM addresses with a postcode not present in CACLR
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:postcode", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:postcode",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:postcode" NOT IN (SELECT code_postal::text FROM addresses);

--- a/metrics/unknown_streets.sql
+++ b/metrics/unknown_streets.sql
@@ -1,7 +1,15 @@
 -- Title: Unknown streets
 -- Description: OSM addresses referencing a street not present in CACLR
 -- include osm_potential_addresses.sql
-SELECT osm_id, osm_type, "addr:housenumber", "addr:street", "addr:city"
+SELECT osm_id,
+       osm_type,
+       url,
+       josmuid,
+       "addr:housenumber",
+       "addr:street",
+       "addr:city",
+       "ref:caclr",
+       "note:caclr"
 FROM osm_potential_addresses
 WHERE "addr:street" NOT IN (SELECT rue FROM addresses)
 ORDER BY "addr:street";

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -8,6 +8,7 @@ import datetime as dt
 import glob
 import os
 from configparser import ConfigParser
+from urllib.parse import quote
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -125,6 +126,7 @@ class Dashboard:
                     "rows": rows,
                     "headers": headers,
                     "josm": self._josm_link(rows, headers),
+                    "overpass": self._overpass_link(rows, headers),
                 }
             self._update_history(slug, value)
             graph = self._plot_history(slug)
@@ -200,6 +202,15 @@ class Dashboard:
             objects.append(f"{prefix}{row[id_idx]}")
         url_tpl = self.config.get("general", "josm_remote_url")
         return url_tpl.format(object_ids=",".join(objects))
+
+    def _overpass_link(self: Dashboard, rows: list[tuple], headers: list[str]) -> str | None:
+        if "osm_id" not in headers or "osm_type" not in headers:
+            return None
+        id_idx = headers.index("osm_id")
+        type_idx = headers.index("osm_type")
+        parts = [f"{rows[i][type_idx]}({rows[i][id_idx]})" for i in range(len(rows))]
+        query = "[out:json];" + "".join(f"{p};" for p in parts) + "out geom;"
+        return f"https://overpass-turbo.eu/?Q={quote(query)}&R"
 
 
 def main() -> None:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -19,7 +19,14 @@
   <td colspan="3">
     <p>{{ metric.description }}</p>
     {% if metric.details %}
-    {% if metric.details.josm %}<p><a href="{{ metric.details.josm }}">Load in JOSM</a></p>{% endif %}
+    {% if metric.details.josm %}
+    <p>
+      <a href="{{ metric.details.josm }}">Load in JOSM</a>
+      {% if metric.details.overpass %}|
+      <a href="{{ metric.details.overpass }}">Overpass Turbo</a>
+      {% endif %}
+    </p>
+    {% endif %}
     <div class="table-container">
     <table class="table is-bordered is-narrow is-fullwidth">
       <thead><tr>{% for h in metric.details.headers %}<th>{{ h }}</th>{% endfor %}</tr></thead>


### PR DESCRIPTION
## Summary
- add Overpass Turbo links alongside JOSM links in dashboard
- provide new metric `streets_missing_in_osm`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uv run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685c85c507a8832faee58a874a2c8550