### PR TITLE
Fix overflow and emphasize titles

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,11 @@
             color: #aaa;
         }
     }
+    .table-container {
+        overflow-x: auto;
+        overflow-y: hidden;
+        max-width: 100%;
+    }
     </style>
 </head>
 <body>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -11,7 +11,7 @@
 <tbody>
 {% for metric in metrics %}
 <tr class="toggle{% if metric.value == 0 %} zero-result{% endif %}" data-target="d-{{ metric.slug }}" data-value="{{ metric.value }}">
-  <td><span class="icon">&#9654;</span> {{ metric.title }}</td>
+  <td><span class="icon">&#9654;</span> <strong>{{ metric.title }}</strong></td>
   <td>{{ metric.value }}</td>
   <td>{% if metric.graph %}<img src="{{ metric.graph }}" alt="trend" style="height:40px">{% endif %}</td>
 </tr>


### PR DESCRIPTION
## Summary
- allow horizontal scrolling in tables
- emphasize metric titles

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uv run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d8030eb54832f935945ba3b548116