### PR TITLE
Fix overflow and emphasize titles

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,14 @@
             color: #aaa;
         }
     }
+    .table-container {
+        display: block;
+        width: 100%;
+        overflow-x: auto;
+    }
+    .table-container table {
+        width: max-content;
+    }
     </style>
 </head>
 <body>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,6 +4,7 @@
 <div class="mb-3">
   <button id="toggle-zero" class="button is-small">Hide Zero Results</button>
 </div>
+<div class="table-container">
 <table class="table is-striped is-hoverable" id="metrics-table">
 <thead id="metrics-head">
 <tr><th>Metric</th><th>Value</th><th>Trend</th></tr>
@@ -11,7 +12,7 @@
 <tbody>
 {% for metric in metrics %}
 <tr class="toggle{% if metric.value == 0 %} zero-result{% endif %}" data-target="d-{{ metric.slug }}" data-value="{{ metric.value }}">
-  <td><span class="icon">&#9654;</span> {{ metric.title }}</td>
+  <td><span class="icon">&#9654;</span> <strong>{{ metric.title }}</strong></td>
   <td>{{ metric.value }}</td>
   <td>{% if metric.graph %}<img src="{{ metric.graph }}" alt="trend" style="height:40px">{% endif %}</td>
 </tr>
@@ -43,6 +44,7 @@
 {% endfor %}
 </tbody>
 </table>
+</div>
 {% endblock %}
 {% block extra_scripts %}
 <script>


### PR DESCRIPTION
## Summary
- allow horizontal scrolling in tables
- emphasize metric titles

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uv run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d8030eb54832f935945ba3b548116