### PR TITLE
Fix parcel id column in SQL metric

### DIFF
--- a/metrics/wrong_parcel_addresses.sql
+++ b/metrics/wrong_parcel_addresses.sql
@@ -74,7 +74,7 @@ AND osm."addr:housenumber" = caclr.numero
 AND osm."addr:city" = caclr.localite
 AND osm."addr:postcode" = caclr.code_postal::text
 AND osm."addr:street" = caclr.rue
-AND caclr.id_parcelle = parcelles.id_parcell
+AND caclr.id_parcelle = parcelles.id_parcelle
 AND NOT st_intersects(osm.way, st_transform(parcelles.wkb_geometry, 3857))
 ORDER BY dist DESC) AS foo
 WHERE dist > 10;


### PR DESCRIPTION
## Summary
- fix column name `parcelles.id_parcell` typo in metrics/wrong_parcel_addresses.sql

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68626a2e65bc832f8c19fae6a4364af3