### PR TITLE
Improve metric file validation

### DIFF
--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -35,6 +35,8 @@ def load_metrics(metric_dir: str, include_dir: str) -> list[tuple[str, str, str,
 
         title = slug.replace("_", " ").title()
         description = "[No description]"
+        has_title = False
+        has_description = False
         sql_lines: list[str] = []
         header = True
         for line in lines:
@@ -52,14 +54,19 @@ def load_metrics(metric_dir: str, include_dir: str) -> list[tuple[str, str, str,
                 lower = comment.lower()
                 if lower.startswith("title:"):
                     title = comment.split(":", 1)[1].strip()
+                    has_title = True
                 elif lower.startswith("description:"):
                     description = comment.split(":", 1)[1].strip()
+                    has_description = True
                 else:
                     # ignore other comment lines in header
                     pass
                 continue
             header = False
             sql_lines.append(line)
+
+        if not has_title or not has_description:
+            raise ValueError(f"{os.path.basename(path)} missing title or description")
 
         sql = "".join(sql_lines).strip()
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -69,7 +69,7 @@ def test_run_creates_html(tmp_path):
     cfg = make_config(tmp_path)
     metric_dir = cfg["paths"]["metrics_dir"]
     with open(os.path.join(metric_dir, "a.sql"), "w", encoding="utf-8") as fh:
-        fh.write("select 1 as col;\n")
+        fh.write("-- Title: A\n-- Description: d\nselect 1 as col;\n")
     dash = make_dashboard(cfg)
     with patch.object(dash, "_fetch_rows", return_value=([(1,)], ["col"])):
         dash.run()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,8 @@
 import glob
 import os
 
+import pytest
+
 from scripts.generate_dashboard import load_metrics
 
 
@@ -33,3 +35,29 @@ def test_load_metrics_includes_osm_addresses():
         slug = os.path.splitext(os.path.basename(path))[0]
         if "-- include osm_potential_addresses.sql" in content.lower():
             assert "with osm_potential_addresses" in metric_map[slug].lower()
+
+
+def test_load_metrics_missing_header(tmp_path):
+    metric_dir = tmp_path / "metrics"
+    include_dir = tmp_path / "inc"
+    metric_dir.mkdir()
+    include_dir.mkdir()
+
+    metric_path = metric_dir / "a.sql"
+    # Missing title
+    metric_path.write_text("-- Description: desc\nselect 1;", encoding="utf-8")
+    with pytest.raises(ValueError, match="a.sql"):
+        load_metrics(str(metric_dir), str(include_dir))
+
+    # Missing description
+    metric_path.write_text("-- Title: t\nselect 1;", encoding="utf-8")
+    with pytest.raises(ValueError, match="a.sql"):
+        load_metrics(str(metric_dir), str(include_dir))
+
+    # Provide both
+    metric_path.write_text(
+        "-- Title: t\n-- Description: d\nselect 1;",
+        encoding="utf-8",
+    )
+    metrics = load_metrics(str(metric_dir), str(include_dir))
+    assert metrics[0][0] == "a"


### PR DESCRIPTION
## Summary
- require metrics to define a Title and Description in `load_metrics`
- add tests for missing header handling
- update dashboard test metric to include headers

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626e4e54cc832f8026f6677e7a6107