### PR TITLE
Refactor metrics with dataclass

### DIFF
--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -89,8 +89,12 @@ class Dashboard:
 
     def __init__(self: Dashboard, config: ConfigParser) -> None:
         self.config = config
-        self.output_dir = Path(self.config.get("paths", "output_dir", fallback="output"))
-        self.history_dir = Path(self.config.get("paths", "history_dir", fallback="history"))
+        self.output_dir = Path(
+            self.config.get("paths", "output_dir", fallback="output")
+        )
+        self.history_dir = Path(
+            self.config.get("paths", "history_dir", fallback="history")
+        )
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.history_dir.mkdir(parents=True, exist_ok=True)
         (self.output_dir / "img").mkdir(parents=True, exist_ok=True)
@@ -128,7 +132,9 @@ class Dashboard:
                 try:
                     rows, headers = fut.result()
                 except Exception as exc:  # pragma: no cover - passthrough
-                    raise RuntimeError(f"error in metric '{metric.slug}': {exc}") from exc
+                    raise RuntimeError(
+                        f"error in metric '{metric.slug}': {exc}"
+                    ) from exc
                 results.append((metric, rows, headers))
 
         for metric, rows, headers in sorted(results, key=lambda r: r[0].slug):
@@ -206,7 +212,9 @@ class Dashboard:
         plt.close()
         return str(img_path.relative_to(self.output_dir))
 
-    def _josm_link(self: Dashboard, rows: list[tuple], headers: list[str]) -> str | None:
+    def _josm_link(
+        self: Dashboard, rows: list[tuple], headers: list[str]
+    ) -> str | None:
         if "osm_id" not in headers or "osm_type" not in headers:
             return None
         id_idx = headers.index("osm_id")
@@ -218,7 +226,9 @@ class Dashboard:
         url_tpl = self.config.get("general", "josm_remote_url")
         return url_tpl.format(object_ids=",".join(objects))
 
-    def _overpass_link(self: Dashboard, rows: list[tuple], headers: list[str]) -> str | None:
+    def _overpass_link(
+        self: Dashboard, rows: list[tuple], headers: list[str]
+    ) -> str | None:
         if "osm_id" not in headers or "osm_type" not in headers:
             return None
         id_idx = headers.index("osm_id")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -7,10 +7,10 @@ from scripts.generate_dashboard import load_metrics
 def test_load_metrics():
     metrics = load_metrics("metrics", "includes")
     assert metrics
-    for slug, title, desc, sql in metrics:
-        assert slug and sql
-        assert isinstance(title, str)
-        assert isinstance(desc, str)
+    for metric in metrics:
+        assert metric.slug and metric.sql
+        assert isinstance(metric.title, str)
+        assert isinstance(metric.description, str)
 
 
 def test_osm_potential_addresses_imports():
@@ -26,7 +26,7 @@ def test_osm_potential_addresses_imports():
 
 
 def test_load_metrics_includes_osm_addresses():
-    metric_map = {slug: sql for slug, _, _, sql in load_metrics("metrics", "includes")}
+    metric_map = {metric.slug: metric.sql for metric in load_metrics("metrics", "includes")}
     for path in glob.glob(os.path.join("metrics", "**", "*.sql"), recursive=True):
         with open(path) as fh:
             content = fh.read()


### PR DESCRIPTION
## Summary
- define a small `Metric` dataclass
- use that dataclass when loading metrics and generating the dashboard
- update the tests for the new structure
- format the dashboard code with black

## Testing
- `uv run python -m py_compile $(git ls-files '*.py')`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68626e593988832f8b094a97cd7d43ae