### PR TITLE
Integrate Rich for colourful logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,12 @@ exclude_rules = "L003"
 name = "osm-caclr-address-dashboard"
 version = "0.0.0"
 requires-python = ">=3.12"
-dependencies = ["psycopg2-binary", "Jinja2", "matplotlib"]
+dependencies = [
+    "psycopg2-binary",
+    "Jinja2",
+    "matplotlib",
+    "rich>=14.0.0",
+]
 
 [dependency-groups]
 dev = [

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+from rich.logging import RichHandler
 
 import csv
 import datetime as dt
@@ -21,11 +22,11 @@ from psycopg2.pool import ThreadedConnectionPool
 
 matplotlib.use("Agg")
 
-logging.basicConfig(level=logging.INFO, format="%(message)s")
-CYAN = "\x1b[36m"
-BLUE = "\x1b[34m"
-GREEN = "\x1b[32m"
-RESET = "\x1b[0m"
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(message)s",
+    handlers=[RichHandler(markup=True, rich_tracebacks=True)],
+)
 
 # Default configuration file path
 CONFIG_FILE = os.environ.get("DASHBOARD_CONFIG", "config.ini")
@@ -127,11 +128,9 @@ class Dashboard:
         start = dt.datetime.now()
         metric_defs = list(load_metrics(metric_dir, include_dir))
         logging.info(
-            "%sLoaded %d metrics in %.2fs%s",
-            CYAN,
+            "[cyan]Loaded %d metrics in %.2fs[/cyan]",
             len(metric_defs),
             (dt.datetime.now() - start).total_seconds(),
-            RESET,
         )
         results: list[tuple[Metric, list[tuple], list[str]]] = []
         from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -147,12 +146,10 @@ class Dashboard:
                 except Exception as exc:  # pragma: no cover - passthrough
                     raise RuntimeError(f"error in metric '{metric.slug}': {exc}") from exc
                 logging.info(
-                    "%sQuery '%s' returned %d rows in %.2fs%s",
-                    BLUE,
+                    "[blue]Query '%s' returned %d rows in %.2fs[/blue]",
                     metric.slug,
                     len(rows),
                     (dt.datetime.now() - start_t).total_seconds(),
-                    RESET,
                 )
                 results.append((metric, rows, headers))
 
@@ -187,11 +184,9 @@ class Dashboard:
         with out_file.open("w", encoding="utf-8") as fh:
             fh.write(html)
         logging.info(
-            "%sWrote HTML in %.2fs to %s%s",
-            GREEN,
+            "[green]Wrote HTML in %.2fs to %s[/green]",
             (dt.datetime.now() - start).total_seconds(),
             out_file,
-            RESET,
         )
         self.pool.closeall()
 

--- a/uv.lock
+++ b/uv.lock
@@ -237,6 +237,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -312,6 +324,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -360,6 +381,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "matplotlib" },
     { name = "psycopg2-binary" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -374,6 +396,7 @@ requires-dist = [
     { name = "jinja2" },
     { name = "matplotlib" },
     { name = "psycopg2-binary" },
+    { name = "rich", specifier = ">=14.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -613,6 +636,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/e3/c446a64984ea9f69982ba1a69d4658d5014bc7a0ea468a07e1a1265db6e2/regex-2024.11.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f51f88c126370dcec4908576c5a627220da6c09d0bff31cfa89f2523843316d", size = 787733, upload-time = "2024-11-06T20:11:11.256Z" },
     { url = "https://files.pythonhosted.org/packages/2b/f1/e40c8373e3480e4f29f2692bd21b3e05f296d3afebc7e5dcf21b9756ca1c/regex-2024.11.6-cp313-cp313-win32.whl", hash = "sha256:63b13cfd72e9601125027202cad74995ab26921d8cd935c25f09c630436348ff", size = 262122, upload-time = "2024-11-06T20:11:13.161Z" },
     { url = "https://files.pythonhosted.org/packages/45/94/bc295babb3062a731f52621cdc992d123111282e291abaf23faa413443ea/regex-2024.11.6-cp313-cp313-win_amd64.whl", hash = "sha256:2b3361af3198667e99927da8b84c1b010752fa4b1115ee30beaa332cabc3ef1a", size = 273545, upload-time = "2024-11-06T20:11:15Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `rich` to dependencies
- use `RichHandler` for colourful logging in the dashboard generator

## Testing
- `uv run pytest -q`
- `uv run ruff check .`
- `uv run black --check .`
- `uv run sqlfluff lint metrics`

------
https://chatgpt.com/codex/tasks/task_e_686287a6c5f8832f89400fec2e742851