### PR TITLE
Add high-confidence missing ref metric

### DIFF
--- a/metrics/ref_missing_wrong_most_probably.sql
+++ b/metrics/ref_missing_wrong_most_probably.sql
@@ -1,0 +1,28 @@
+-- Title: Most probably incorrect missing ref
+-- Description: Objects tagged ref:caclr=missing but overlapping a CACLR address where the housenumber and street match
+-- include osm_potential_addresses_withgeom.sql
+
+-- 8< cut here >8 --
+
+SELECT
+         osm.osm_id,
+         osm.url,
+         osm.josmuid,
+         osm."addr:housenumber",
+         caclr.numero,
+         osm."addr:street",
+         caclr.rue,
+         osm."addr:city",
+         caclr.localite,
+         osm."note:caclr",
+         osm.note,
+         osm."ref:caclr",
+         caclr.id_caclr_bat
+FROM osm_potential_addresses AS osm,
+         addresses AS caclr
+WHERE osm."ref:caclr" LIKE 'missing'
+AND osm.way && caclr.geom_3857
+AND st_intersects(osm.way, caclr.geom_3857)
+AND osm."addr:housenumber" = caclr.numero::text
+AND osm."addr:street" = caclr.rue
+ORDER BY localite, rue, numero;


### PR DESCRIPTION
## Summary
- add new SQL metric `ref_missing_wrong_most_probably.sql`

## Testing
- `uv run ruff check .`
- `uv run black --check .`
- `uv run sqlfluff lint metrics --dialect postgres`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644c43b4d8832f90c2fd4cb89c13f8