### PR TITLE
Add more CACLR timestamps in metrics

### DIFF
--- a/metrics/addresses_without_housenumber_not_in_osm.sql
+++ b/metrics/addresses_without_housenumber_not_in_osm.sql
@@ -4,10 +4,15 @@
 SELECT
     a.id_caclr_bat,
     a.rue,
-    a.localite
+    a.localite,
+    i.date_debut_valid,
+    i.ds_timestamp_modif,
+    opa.osm_timestamp
 FROM addresses AS a
 LEFT JOIN osm_potential_addresses AS opa
     ON a.id_caclr_bat = opa."ref:caclr"
+LEFT JOIN immeuble AS i
+    ON a.id_caclr_bat = i.numero_interne
 WHERE
     a.numero IS NULL
     AND opa.osm_id IS NULL

--- a/metrics/caclr_mismatch.sql
+++ b/metrics/caclr_mismatch.sql
@@ -12,10 +12,14 @@ SELECT
     opa."addr:city" AS osm_city,
     a.localite AS caclr_city,
     opa."ref:caclr",
-    opa."note:caclr"
+    opa."note:caclr",
+    i.ds_timestamp_modif,
+    opa.osm_timestamp
 FROM osm_potential_addresses AS opa
 INNER JOIN addresses AS a
     ON opa."ref:caclr" = a.id_caclr_bat
+LEFT JOIN immeuble AS i
+    ON opa."ref:caclr" = i.numero_interne
 WHERE
     opa."addr:street" != a.rue
     OR opa."addr:city" != a.localite

--- a/metrics/far_match_addresses.sql
+++ b/metrics/far_match_addresses.sql
@@ -33,6 +33,10 @@ addresses_prepped AS (
       localite          AS city,
       st_transform(geom, 2169) AS geom2169
     FROM addresses
+),
+immeuble_dates AS (
+    SELECT numero_interne, ds_timestamp_modif
+    FROM immeuble
 )
 
 SELECT
@@ -51,6 +55,7 @@ SELECT
   f.note,
   f."note:caclr",
   a.id_caclr_bat,
+  i.ds_timestamp_modif,
   st_distance(f.centroid, a.geom2169) AS dist,
   st_astext(st_shortestline(f.centroid, a.geom2169)) AS line
 FROM filtered_osm AS f
@@ -59,5 +64,7 @@ JOIN addresses_prepped AS a
  AND f.street      = a.street
  AND f.postcode    = a.postcode
  AND f.city        = a.city
+LEFT JOIN immeuble_dates AS i
+  ON a.id_caclr_bat = i.numero_interne
 WHERE st_distance(f.centroid, a.geom2169) > 30
 ORDER BY dist DESC;

--- a/metrics/missing_caclr_reference.sql
+++ b/metrics/missing_caclr_reference.sql
@@ -11,10 +11,15 @@ SELECT
     opa."addr:postcode",
     opa."addr:city",
     opa."ref:caclr",
-    opa."note:caclr"
+    opa."note:caclr",
+    i.date_fin_valid,
+    i.ds_timestamp_modif,
+    opa.osm_timestamp
 FROM osm_potential_addresses AS opa
 LEFT JOIN addresses AS a
     ON opa."ref:caclr" = a.id_caclr_bat
+LEFT JOIN immeuble AS i
+    ON opa."ref:caclr" = i.numero_interne
 WHERE
     a.id_caclr_bat IS NULL
     AND opa."ref:caclr" NOT IN ('missing', 'wrong')

--- a/metrics/no_match_in_caclr.sql
+++ b/metrics/no_match_in_caclr.sql
@@ -5,6 +5,7 @@
 SELECT
     osm.osm_id,
     osm.osm_type,
+    osm.osm_timestamp,
     osm.url,
     osm.josmuid,
     osm.osm_user,

--- a/metrics/ref_missing_wrong.sql
+++ b/metrics/ref_missing_wrong.sql
@@ -6,6 +6,7 @@
 
 SELECT
     osm.osm_id,
+    osm.osm_timestamp,
     osm.url,
     osm.josmuid,
     osm."addr:housenumber",
@@ -17,13 +18,18 @@ SELECT
     osm."note:caclr",
     osm.note,
     osm."ref:caclr",
-    caclr.id_caclr_bat
-FROM osm_potential_addresses AS osm,
-    addresses AS caclr
+    caclr.id_caclr_bat,
+    i.ds_timestamp_modif
+FROM osm_potential_addresses AS osm
+INNER JOIN addresses AS caclr
+    ON (
+        osm.way && caclr.geom_3857
+        AND st_intersects(osm.way, caclr.geom_3857)
+    )
+LEFT JOIN immeuble AS i
+    ON caclr.id_caclr_bat = i.numero_interne
 WHERE
     osm."ref:caclr" LIKE 'missing'
-    AND osm.way && caclr.geom_3857
-    AND st_intersects(osm.way, caclr.geom_3857)
 ORDER BY
     caclr.localite,
     caclr.rue,

--- a/metrics/ref_missing_wrong_most_probably.sql
+++ b/metrics/ref_missing_wrong_most_probably.sql
@@ -6,6 +6,7 @@
 
 SELECT
     osm.osm_id,
+    osm.osm_timestamp,
     osm.url,
     osm.josmuid,
     osm."addr:housenumber",
@@ -17,13 +18,18 @@ SELECT
     osm."note:caclr",
     osm.note,
     osm."ref:caclr",
-    caclr.id_caclr_bat
-FROM osm_potential_addresses AS osm,
-    addresses AS caclr
+    caclr.id_caclr_bat,
+    i.ds_timestamp_modif
+FROM osm_potential_addresses AS osm
+INNER JOIN addresses AS caclr
+    ON (
+        osm.way && caclr.geom_3857
+        AND st_intersects(osm.way, caclr.geom_3857)
+    )
+LEFT JOIN immeuble AS i
+    ON caclr.id_caclr_bat = i.numero_interne
 WHERE
     osm."ref:caclr" LIKE 'missing'
-    AND osm.way && caclr.geom_3857
-    AND st_intersects(osm.way, caclr.geom_3857)
     AND osm."addr:housenumber" = caclr.numero::text
     AND osm."addr:street" = caclr.rue
 ORDER BY

--- a/metrics/wrong_parcel_addresses.sql
+++ b/metrics/wrong_parcel_addresses.sql
@@ -42,6 +42,10 @@ addresses_prepped AS (
     st_transform(geom, 2169) AS addr_geom_2169
   FROM addresses
 ),
+immeuble_dates AS (
+  SELECT numero_interne, ds_timestamp_modif
+  FROM immeuble
+),
 parcelles_prepped AS (
   SELECT
     id_parcell,
@@ -68,6 +72,7 @@ SELECT
   f."note:caclr",
   f.fixme,
   a.id_caclr_bat,
+  i.ds_timestamp_modif,
   p.id_parcell,
   round(
     st_distance(f.centroid, a.addr_geom_2169)
@@ -80,9 +85,11 @@ JOIN addresses_prepped AS a
   ON f.housenumber = a.housenumber
  AND f.street      = a.street
  AND f.postcode    = a.postcode
- AND f.city        = a.city
+  AND f.city        = a.city
 JOIN parcelles_prepped AS p
   ON a.id_parcelle = p.id_parcell
+LEFT JOIN immeuble_dates AS i
+  ON a.id_caclr_bat = i.numero_interne
 WHERE NOT st_intersects(f.geom2169, p.parcelle_geom_2169)
   AND st_distance(f.centroid, a.addr_geom_2169) > 10
 ORDER BY dist DESC;


### PR DESCRIPTION
## Summary
- surface ds_timestamp_modif in several cross-dataset metrics
- include osm_timestamp where applicable for easier comparison

## Testing
- `uv run black . --check`
- `uv run ruff check .`
- `uv run sqlfluff lint metrics`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68677676a074832faec2bdd5e034d2ad