### PR TITLE
Fix joins on numero_interne

### DIFF
--- a/metrics/addresses_without_housenumber_not_in_osm.sql
+++ b/metrics/addresses_without_housenumber_not_in_osm.sql
@@ -12,7 +12,7 @@ FROM addresses AS a
 LEFT JOIN osm_potential_addresses AS opa
     ON a.id_caclr_bat = opa."ref:caclr"
 LEFT JOIN immeuble AS i
-    ON a.id_caclr_bat = i.numero_interne
+    ON a.id_caclr_bat = i.numero_interne::text
 WHERE
     a.numero IS NULL
     AND opa.osm_id IS NULL

--- a/metrics/caclr_mismatch.sql
+++ b/metrics/caclr_mismatch.sql
@@ -19,7 +19,7 @@ FROM osm_potential_addresses AS opa
 INNER JOIN addresses AS a
     ON opa."ref:caclr" = a.id_caclr_bat
 LEFT JOIN immeuble AS i
-    ON opa."ref:caclr" = i.numero_interne
+    ON opa."ref:caclr" = i.numero_interne::text
 WHERE
     opa."addr:street" != a.rue
     OR opa."addr:city" != a.localite

--- a/metrics/far_match_addresses.sql
+++ b/metrics/far_match_addresses.sql
@@ -65,6 +65,6 @@ JOIN addresses_prepped AS a
  AND f.postcode    = a.postcode
  AND f.city        = a.city
 LEFT JOIN immeuble_dates AS i
-  ON a.id_caclr_bat = i.numero_interne
+  ON a.id_caclr_bat = i.numero_interne::text
 WHERE st_distance(f.centroid, a.geom2169) > 30
 ORDER BY dist DESC;

--- a/metrics/missing_caclr_reference.sql
+++ b/metrics/missing_caclr_reference.sql
@@ -19,7 +19,7 @@ FROM osm_potential_addresses AS opa
 LEFT JOIN addresses AS a
     ON opa."ref:caclr" = a.id_caclr_bat
 LEFT JOIN immeuble AS i
-    ON opa."ref:caclr" = i.numero_interne
+    ON opa."ref:caclr" = i.numero_interne::text
 WHERE
     a.id_caclr_bat IS NULL
     AND opa."ref:caclr" NOT IN ('missing', 'wrong')

--- a/metrics/ref_missing_wrong.sql
+++ b/metrics/ref_missing_wrong.sql
@@ -27,7 +27,7 @@ INNER JOIN addresses AS caclr
         AND st_intersects(osm.way, caclr.geom_3857)
     )
 LEFT JOIN immeuble AS i
-    ON caclr.id_caclr_bat = i.numero_interne
+    ON caclr.id_caclr_bat = i.numero_interne::text
 WHERE
     osm."ref:caclr" LIKE 'missing'
 ORDER BY

--- a/metrics/ref_missing_wrong_most_probably.sql
+++ b/metrics/ref_missing_wrong_most_probably.sql
@@ -27,7 +27,7 @@ INNER JOIN addresses AS caclr
         AND st_intersects(osm.way, caclr.geom_3857)
     )
 LEFT JOIN immeuble AS i
-    ON caclr.id_caclr_bat = i.numero_interne
+    ON caclr.id_caclr_bat = i.numero_interne::text
 WHERE
     osm."ref:caclr" LIKE 'missing'
     AND osm."addr:housenumber" = caclr.numero::text

--- a/metrics/wrong_parcel_addresses.sql
+++ b/metrics/wrong_parcel_addresses.sql
@@ -89,7 +89,7 @@ JOIN addresses_prepped AS a
 JOIN parcelles_prepped AS p
   ON a.id_parcelle = p.id_parcell
 LEFT JOIN immeuble_dates AS i
-  ON a.id_caclr_bat = i.numero_interne
+  ON a.id_caclr_bat = i.numero_interne::text
 WHERE NOT st_intersects(f.geom2169, p.parcelle_geom_2169)
   AND st_distance(f.centroid, a.addr_geom_2169) > 10
 ORDER BY dist DESC;


### PR DESCRIPTION
## Summary
- cast `numero_interne` to text when joining with `id_caclr_bat`
- keep formatting and linting clean

## Testing
- `uv run ruff check .`
- `uv run black .`
- `uv run sqlfluff lint metrics`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcb89775c832f91d31c3877a75f74