### PR TITLE
Add fixture database export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,24 @@ checked with `sqlfluff`. These run automatically via GitHub Actions.
 
 Run the following command before committing changes:
 
-```
+```bash
 python -m py_compile $(git ls-files '*.py')
 ```
+
+### Test fixture database
+
+The unit tests rely on `tests/fixture.sqlite`, a SpatiaLite dump of the OSM and
+cadastre tables used by the dashboard. Regenerate this file on a server that has
+the full PostGIS stack **and** all relevant data already imported. `ogr2ogr`
+must be built with SpatiaLite support:
+
+```
+./scripts/dump_fixture_db.py
+```
+
+The script reads the regular configuration file to connect to Postgres and
+exports the tables needed by the dashboard. The OpenStreetMap portion of the
+dump is © OpenStreetMap contributors.
 
 ## Database schema
 

--- a/scripts/dump_fixture_db.py
+++ b/scripts/dump_fixture_db.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import os
 import subprocess
 from argparse import ArgumentParser
-from configparser import ConfigParser
+from configparser import ConfigParser, SectionProxy
+from typing import Mapping
 from pathlib import Path
 
 CONFIG_FILE = os.environ.get("DASHBOARD_CONFIG", "config.ini")
@@ -27,7 +28,7 @@ TABLES = [
 ]
 
 
-def build_dsn(db: ConfigParser) -> str:
+def build_dsn(db: Mapping[str, str] | SectionProxy) -> str:
     """Build libpq connection string for ogr2ogr."""
     parts = [f"port={db.get('port', '5432')}", f"dbname={db['dbname']}"]
     host = db.get("host")

--- a/scripts/dump_fixture_db.py
+++ b/scripts/dump_fixture_db.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env -S uv run
+"""Export dashboard tables from PostGIS to SpatiaLite.
+
+This dumps the OpenStreetMap and cadastre tables needed for the tests into a
+single SpatiaLite file. The OSM portion of the output is
+© OpenStreetMap contributors.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from argparse import ArgumentParser
+from configparser import ConfigParser
+from pathlib import Path
+
+CONFIG_FILE = os.environ.get("DASHBOARD_CONFIG", "config.ini")
+
+# Tables needed for the dashboard and metrics
+TABLES = [
+    "addresses",
+    "immeuble",
+    "parcelles",
+    "planet_osm_point",
+    "planet_osm_line",
+    "planet_osm_polygon",
+]
+
+
+def build_dsn(db: ConfigParser) -> str:
+    """Build libpq connection string for ogr2ogr."""
+    parts = [f"port={db.get('port', '5432')}", f"dbname={db['dbname']}"]
+    host = db.get("host")
+    if host:
+        parts.append(f"host={host}")
+    user = db.get("user")
+    if user:
+        parts.append(f"user={user}")
+    password = db.get("password")
+    if password:
+        parts.append(f"password={password}")
+    return " ".join(parts)
+
+
+def export_tables(sqlite_path: Path, dsn: str) -> None:
+    """Dump all tables to SQLite."""
+    for idx, table in enumerate(TABLES):
+        args = [
+            "ogr2ogr",
+            "-f",
+            "SQLite",
+            "-dsco",
+            "SPATIALITE=YES",
+        ]
+        if idx:
+            args.extend(["-update", "-append"])
+        args.extend([str(sqlite_path), f"PG:{dsn}", table])
+        subprocess.check_call(args)
+
+
+def main() -> None:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "output",
+        type=Path,
+        nargs="?",
+        default=Path("tests/fixture.sqlite"),
+        help="Path to output SQLite database",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(CONFIG_FILE):
+        raise FileNotFoundError(f"Configuration file '{CONFIG_FILE}' not found.")
+
+    cfg = ConfigParser()
+    cfg.read(CONFIG_FILE)
+
+    dsn = build_dsn(cfg["database"])
+    export_tables(args.output, dsn)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python script to dump PostGIS tables into a SpatiaLite database
- document the fixture database regeneration process
- clarify that the dump contains OSM and cadastre data

## Testing
- `uv run ruff check scripts/dump_fixture_db.py scripts/generate_dashboard.py tests`
- `uv run black --check scripts/dump_fixture_db.py scripts/generate_dashboard.py tests`
- `uv run sqlfluff lint metrics --dialect postgres`
- `uv run pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686fd1c818e4832f8dacc361de7df1f0