### PR TITLE
Use opa alias consistently

### DIFF
--- a/metrics/no_match_in_caclr.sql
+++ b/metrics/no_match_in_caclr.sql
@@ -3,27 +3,27 @@
 -- include osm_potential_addresses_street.sql
 
 SELECT
-    osm.osm_id,
-    osm.osm_type,
-    osm.osm_timestamp,
-    osm.url,
-    osm.josmuid,
-    osm.osm_user,
-    osm."addr:housenumber" AS numero,
-    osm."addr:street" AS rue,
-    osm."addr:postcode" AS codepostal,
-    osm."addr:city" AS localite,
-    osm."ref:caclr",
-    osm."note:caclr"
-FROM osm_potential_addresses AS osm
+    opa.osm_id,
+    opa.osm_type,
+    opa.osm_timestamp,
+    opa.url,
+    opa.josmuid,
+    opa.osm_user,
+    opa."addr:housenumber" AS numero,
+    opa."addr:street" AS rue,
+    opa."addr:postcode" AS codepostal,
+    opa."addr:city" AS localite,
+    opa."ref:caclr",
+    opa."note:caclr"
+FROM osm_potential_addresses AS opa
 LEFT JOIN
     addresses AS a
     ON
-        osm."addr:housenumber" = a.numero
-        AND osm."addr:city" = a.localite
-        AND osm."addr:street" = a.rue
+        opa."addr:housenumber" = a.numero
+        AND opa."addr:city" = a.localite
+        AND opa."addr:street" = a.rue
 WHERE
     a.localite IS NULL
-    AND osm."ref:caclr" IS NULL
-    AND osm."addr:housenumber" NOT LIKE '%-%'
+    AND opa."ref:caclr" IS NULL
+    AND opa."addr:housenumber" NOT LIKE '%-%'
 ORDER BY localite, rue, numero;

--- a/metrics/ref_missing_wrong.sql
+++ b/metrics/ref_missing_wrong.sql
@@ -5,31 +5,31 @@
 -- 8< cut here >8 --
 
 SELECT
-    osm.osm_id,
-    osm.osm_timestamp,
-    osm.url,
-    osm.josmuid,
-    osm."addr:housenumber",
+    opa.osm_id,
+    opa.osm_timestamp,
+    opa.url,
+    opa.josmuid,
+    opa."addr:housenumber",
     caclr.numero,
-    osm."addr:street",
+    opa."addr:street",
     caclr.rue,
-    osm."addr:city",
+    opa."addr:city",
     caclr.localite,
-    osm."note:caclr",
-    osm.note,
-    osm."ref:caclr",
+    opa."note:caclr",
+    opa.note,
+    opa."ref:caclr",
     caclr.id_caclr_bat,
     i.ds_timestamp_modif
-FROM osm_potential_addresses AS osm
+FROM osm_potential_addresses AS opa
 INNER JOIN addresses AS caclr
     ON (
-        osm.way && caclr.geom_3857
-        AND st_intersects(osm.way, caclr.geom_3857)
+        opa.way && caclr.geom_3857
+        AND st_intersects(opa.way, caclr.geom_3857)
     )
 LEFT JOIN immeuble AS i
     ON caclr.id_caclr_bat = i.numero_interne::text
 WHERE
-    osm."ref:caclr" LIKE 'missing'
+    opa."ref:caclr" LIKE 'missing'
 ORDER BY
     caclr.localite,
     caclr.rue,

--- a/metrics/ref_missing_wrong_most_probably.sql
+++ b/metrics/ref_missing_wrong_most_probably.sql
@@ -5,33 +5,33 @@
 -- 8< cut here >8 --
 
 SELECT
-    osm.osm_id,
-    osm.osm_timestamp,
-    osm.url,
-    osm.josmuid,
-    osm."addr:housenumber",
+    opa.osm_id,
+    opa.osm_timestamp,
+    opa.url,
+    opa.josmuid,
+    opa."addr:housenumber",
     caclr.numero,
-    osm."addr:street",
+    opa."addr:street",
     caclr.rue,
-    osm."addr:city",
+    opa."addr:city",
     caclr.localite,
-    osm."note:caclr",
-    osm.note,
-    osm."ref:caclr",
+    opa."note:caclr",
+    opa.note,
+    opa."ref:caclr",
     caclr.id_caclr_bat,
     i.ds_timestamp_modif
-FROM osm_potential_addresses AS osm
+FROM osm_potential_addresses AS opa
 INNER JOIN addresses AS caclr
     ON (
-        osm.way && caclr.geom_3857
-        AND st_intersects(osm.way, caclr.geom_3857)
+        opa.way && caclr.geom_3857
+        AND st_intersects(opa.way, caclr.geom_3857)
     )
 LEFT JOIN immeuble AS i
     ON caclr.id_caclr_bat = i.numero_interne::text
 WHERE
-    osm."ref:caclr" LIKE 'missing'
-    AND osm."addr:housenumber" = caclr.numero::text
-    AND osm."addr:street" = caclr.rue
+    opa."ref:caclr" LIKE 'missing'
+    AND opa."addr:housenumber" = caclr.numero::text
+    AND opa."addr:street" = caclr.rue
 ORDER BY
     caclr.localite,
     caclr.rue,


### PR DESCRIPTION
## Summary
- unify the table alias for `osm_potential_addresses` across metrics

## Testing
- `uv run black .`
- `uv run ruff check .`
- `uv run sqlfluff lint metrics`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68719f5b3028832fa2aec977d3de2d14